### PR TITLE
Profile Management

### DIFF
--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -428,15 +428,23 @@ export function Panafall(props: { index: number }) {
                           <ContextMenuPortal>
                             <ContextMenuSubContent>
                               <ContextMenuGroup>
-                                <ContextMenuItem
-                                  onSelect={() =>
-                                    radio().saveGlobalProfile(
+                                <Show
+                                  when={state.status.radio.profileGlobalList.find(
+                                    (profile) =>
+                                      profile ===
                                       state.status.radio.profileGlobalSelection,
-                                    )
-                                  }
+                                  )}
                                 >
-                                  {`Save ${state.status.radio.profileGlobalSelection}`}
-                                </ContextMenuItem>
+                                  {(profile) => (
+                                    <ContextMenuItem
+                                      onSelect={() =>
+                                        radio().saveGlobalProfile(profile())
+                                      }
+                                    >
+                                      {`Save ${profile()}`}
+                                    </ContextMenuItem>
+                                  )}
+                                </Show>
                                 <ContextMenuItem
                                   onSelect={() => setCreateProfile(true)}
                                 >

--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -9,6 +9,7 @@ import {
   ComponentProps,
   splitProps,
   ValidComponent,
+  For,
 } from "solid-js";
 import { Panadapter } from "./panadapter";
 import { Waterfall } from "./waterfall";
@@ -33,12 +34,18 @@ import {
   ContextMenuCheckboxItem,
   ContextMenuGroup,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
 } from "../ui/context-menu";
 import { usePanafall } from "~/context/panafall";
 import { createWindowSize } from "@solid-primitives/resize-observer";
 import { usePreferences } from "~/context/preferences";
 import { Toggle } from "../ui/toggle";
 import { PanafallControl } from "./controls";
+import { CreateProfileDialog } from "../settings/profile-settings";
 
 type PanafallButtonProps<T extends ValidComponent = "button"> = ComponentProps<
   typeof TooltipTrigger<T>
@@ -100,6 +107,7 @@ export function Panafall(props: { index: number }) {
   const { preferences, setPreferences } = usePreferences();
   const { radio, state } = useFlexRadio();
   const [clickRef, setClickRef] = createSignal<HTMLElement>();
+  const [createProfile, setCreateProfile] = createSignal(false);
 
   const [dragState, setDragState] = createStore({
     down: false,
@@ -323,6 +331,12 @@ export function Panafall(props: { index: number }) {
         <Show when={panadapter()}>
           {(pan) => (
             <>
+              <CreateProfileDialog
+                radio={radio()}
+                kind="global"
+                open={createProfile()}
+                onOpenChange={setCreateProfile}
+              />
               <div class="relative size-full overflow-visible select-none">
                 <Resizable
                   class="size-full overflow-visible select-none"
@@ -406,6 +420,64 @@ export function Panafall(props: { index: number }) {
                           </div>
                           {`Create TNF at ${Math.round(xToFreq(pos.x) * 1_000_000).toLocaleString("de-DE")} Hz`}
                         </ContextMenuItem>
+                      </ContextMenuGroup>
+                      <ContextMenuSeparator />
+                      <ContextMenuGroup>
+                        <ContextMenuSub overlap>
+                          <ContextMenuSubTrigger>Profile</ContextMenuSubTrigger>
+                          <ContextMenuPortal>
+                            <ContextMenuSubContent>
+                              <ContextMenuGroup>
+                                <ContextMenuItem
+                                  onSelect={() =>
+                                    radio().saveGlobalProfile(
+                                      state.status.radio.profileGlobalSelection,
+                                    )
+                                  }
+                                >
+                                  {`Save ${state.status.radio.profileGlobalSelection}`}
+                                </ContextMenuItem>
+                                <ContextMenuItem
+                                  onSelect={() => setCreateProfile(true)}
+                                >
+                                  Create New...
+                                </ContextMenuItem>
+                              </ContextMenuGroup>
+                              <ContextMenuSeparator />
+                              <ContextMenuGroup>
+                                <ContextMenuCheckboxItem
+                                  checked={state.status.radio.profileAutoSave}
+                                  onChange={(checked) => {
+                                    radio().setProfileAutoSave(checked);
+                                  }}
+                                >
+                                  Enable Profile Auto-Save
+                                </ContextMenuCheckboxItem>
+                              </ContextMenuGroup>
+                              <ContextMenuSeparator />
+                              <ContextMenuRadioGroup
+                                value={
+                                  state.status.radio.profileGlobalSelection
+                                }
+                                onChange={(profile) =>
+                                  radio().loadGlobalProfile(profile)
+                                }
+                              >
+                                <For
+                                  each={Array.from(
+                                    state.status.radio.profileGlobalList,
+                                  )}
+                                >
+                                  {(profile) => (
+                                    <ContextMenuRadioItem value={profile}>
+                                      {profile}
+                                    </ContextMenuRadioItem>
+                                  )}
+                                </For>
+                              </ContextMenuRadioGroup>
+                            </ContextMenuSubContent>
+                          </ContextMenuPortal>
+                        </ContextMenuSub>
                       </ContextMenuGroup>
                       <ContextMenuSeparator />
                       <ContextMenuGroup>

--- a/apps/web/src/components/right-sidebar.tsx
+++ b/apps/web/src/components/right-sidebar.tsx
@@ -58,16 +58,24 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { EqualizerBand } from "@repo/flexlib/flex/state/equalizer";
 import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+import MaterialSymbolsMoreVert from "~icons/material-symbols/more-vert";
+import { CreateProfileDialog } from "./settings/profile-settings";
 
 const PROCESSOR_LEVELS = ["Norm", "DX", "DX+"];
 const VOICE_MODES = new Set(["USB", "LSB", "AM", "SAM", "FM", "NFM"]);
 
 function TxSection() {
   const { state, radio } = useFlexRadio();
-  const [txProfiles, setTxProfiles] = createStore<string[]>([]);
   const [rawRfPower, setRawRfPower] = createSignal(0);
   const [fwdPwrWatts, setFwdPwrWatts] = createSignal(0);
   const [refPwrWatts, setRefPwrWatts] = createSignal(0);
+  const [createProfile, setCreateProfile] = createSignal(false);
 
   const setRfPower = (value: number) => {
     if (value !== state.status.radio.rfPower) {
@@ -117,10 +125,14 @@ function TxSection() {
     return (1 + x) / (1 - x);
   });
 
-  createEffect(() => setTxProfiles(state?.status?.radio?.profileTxList ?? []));
-
   return (
     <AccordionItem value="tx">
+      <CreateProfileDialog
+        open={createProfile()}
+        onOpenChange={setCreateProfile}
+        radio={radio()}
+        kind="tx"
+      />
       <AccordionTrigger>Transmit</AccordionTrigger>
       <AccordionContent>
         <div class="text-sm flex flex-col gap-3 overflow-visible">
@@ -210,13 +222,14 @@ function TxSection() {
             label="Tune Power"
           />
           <Select
-            class="flex flex-col gap-2 select-none"
+            class="flex flex-col gap-2 select-none relative"
             value={state.status.radio.profileTxSelection}
             onChange={(value: string) => {
-              if (!value) return;
+              if (!value || value === state.status.radio.profileTxSelection)
+                return;
               radio()?.loadTxProfile(value);
             }}
-            options={txProfiles}
+            options={Array.from(state.status.radio.profileTxList)}
             itemComponent={(props) => {
               return (
                 <SelectItem item={props.item}>{props.item.rawValue}</SelectItem>
@@ -224,11 +237,68 @@ function TxSection() {
             }}
           >
             <SelectLabel>TX Profile</SelectLabel>
-            <SelectTrigger>
-              <SelectValue<string>>
-                {(state) => state.selectedOption()}
+            <SelectTrigger class="w-auto mr-12">
+              <SelectValue<string> class="overflow-hidden">
+                {({ selectedOption }) => (
+                  <div class="flex gap-3 items-center">
+                    <Show when={state.status.radio.profileUnsavedChangesTx}>
+                      <div class="rounded-full size-2 bg-warning-foreground shrink-0" />
+                    </Show>
+                    <div class="overflow-hidden whitespace-nowrap text-ellipsis">
+                      {selectedOption()}
+                    </div>
+                  </div>
+                )}
               </SelectValue>
             </SelectTrigger>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                as={Button}
+                size="icon"
+                class="absolute right-0 bottom-0"
+              >
+                <MaterialSymbolsMoreVert />
+              </DropdownMenuTrigger>
+
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  disabled={
+                    !state.status.radio.profileTxSelection ||
+                    !state.status.radio.profileUnsavedChangesTx
+                  }
+                  onSelect={() =>
+                    radio().createTxProfile(
+                      state.status.radio.profileTxSelection,
+                    )
+                  }
+                >
+                  Save
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setCreateProfile(true)}>
+                  Save As...
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={!state.status.radio.profileTxSelection}
+                  onSelect={() =>
+                    radio().resetTxProfile(
+                      state.status.radio.profileTxSelection,
+                    )
+                  }
+                >
+                  Reset
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={!state.status.radio.profileTxSelection}
+                  onSelect={() =>
+                    radio().deleteTxProfile(
+                      state.status.radio.profileTxSelection,
+                    )
+                  }
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
             <SelectContent />
           </Select>
           <SimpleSwitch
@@ -332,15 +402,9 @@ function TxSection() {
 
 function MicSection() {
   const { state, radio } = useFlexRadio();
-  const [micInputList, setMicInputList] = createStore<string[]>([]);
-  const [micProfileList, setMicProfileList] = createStore<string[]>([]);
   const [micPeakValue, setMicPeakValue] = createSignal(-150);
   const [compPeakValue, setCompPeakValue] = createSignal(-150);
-
-  createEffect(() => setMicInputList(state?.status?.radio?.micInputList ?? []));
-  createEffect(() =>
-    setMicProfileList(state?.status?.radio?.profileMicList ?? []),
-  );
+  const [createProfile, setCreateProfile] = createSignal(false);
 
   const micMeter = createMemo(() =>
     Object.values(state.status.meter).find((meter) => meter.name === "MIC"),
@@ -381,6 +445,12 @@ function MicSection() {
 
   return (
     <div class="flex flex-col gap-3">
+      <CreateProfileDialog
+        open={createProfile()}
+        onOpenChange={setCreateProfile}
+        radio={radio()}
+        kind="mic"
+      />
       <Show when={micMeter()}>
         {(acc) => {
           const meter = acc();
@@ -437,13 +507,14 @@ function MicSection() {
         }}
       </Show>
       <Select
-        class="flex flex-col gap-2 select-none"
+        class="flex flex-col gap-2 select-none relative"
         value={state.status.radio.profileMicSelection}
         onChange={(value: string) => {
-          if (!value) return;
+          if (!value || value === state.status.radio.profileMicSelection)
+            return;
           radio()?.loadMicProfile(value);
         }}
-        options={micProfileList}
+        options={Array.from(state.status.radio.profileMicList)}
         itemComponent={(props) => {
           return (
             <SelectItem item={props.item}>{props.item.rawValue}</SelectItem>
@@ -451,19 +522,72 @@ function MicSection() {
         }}
       >
         <SelectLabel>Mic Profile</SelectLabel>
-        <SelectTrigger>
-          <SelectValue<string>>{(state) => state.selectedOption()}</SelectValue>
+        <SelectTrigger class="w-auto mr-12">
+          <SelectValue<string> class="overflow-hidden">
+            {({ selectedOption }) => (
+              <div class="flex gap-3 items-center">
+                <Show when={state.status.radio.profileUnsavedChangesMic}>
+                  <div class="rounded-full size-2 bg-warning-foreground shrink-0" />
+                </Show>
+                <div class="overflow-hidden whitespace-nowrap text-ellipsis">
+                  {selectedOption()}
+                </div>
+              </div>
+            )}
+          </SelectValue>
         </SelectTrigger>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            as={Button}
+            size="icon"
+            class="absolute right-0 bottom-0"
+          >
+            <MaterialSymbolsMoreVert />
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent>
+            <DropdownMenuItem
+              disabled={
+                !state.status.radio.profileMicSelection ||
+                !state.status.radio.profileUnsavedChangesMic
+              }
+              onSelect={() =>
+                radio().createMicProfile(state.status.radio.profileMicSelection)
+              }
+            >
+              Save
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setCreateProfile(true)}>
+              Save As...
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!state.status.radio.profileMicSelection}
+              onSelect={() =>
+                radio().resetMicProfile(state.status.radio.profileMicSelection)
+              }
+            >
+              Reset
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!state.status.radio.profileMicSelection}
+              onSelect={() =>
+                radio().deleteMicProfile(state.status.radio.profileMicSelection)
+              }
+            >
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <SelectContent />
       </Select>
       <Select
         class="flex flex-col gap-2 select-none"
         value={state.status.radio.micSelection}
         onChange={(value: string) => {
-          if (!value) return;
+          if (!value || value === state.status.radio.micSelection) return;
           radio()?.setMicSelection(value);
         }}
-        options={micInputList}
+        options={Array.from(state.status.radio.micInputList)}
         itemComponent={(props) => {
           return (
             <SelectItem item={props.item}>{props.item.rawValue}</SelectItem>

--- a/apps/web/src/components/settings/audio-settings.tsx
+++ b/apps/web/src/components/settings/audio-settings.tsx
@@ -33,13 +33,11 @@ import { Callout, CalloutContent, CalloutTitle } from "../ui/callout";
 import { createPermission } from "~/lib/permission";
 import { ToggleButton } from "@kobalte/core/toggle-button";
 import { SimpleSlider } from "../ui/simple-slider";
-import { Button } from "../ui/button";
 import MdiSpeaker from "~icons/mdi/speaker";
 import MdiSpeakerOff from "~icons/mdi/speaker-off";
 import MdiHeadphones from "~icons/mdi/headphones";
 import MdiHeadphonesOff from "~icons/mdi/headphones-off";
 import { Dynamic } from "solid-js/web";
-import { ToggleGroupItem } from "../ui/toggle-group";
 
 function InnerAudioSettings() {
   const { audioStreams } = useRuntime();
@@ -111,7 +109,7 @@ function InnerAudioSettings() {
           label="RX Only"
         />
         <Select
-          class="flex flex-col gap-2 grow shrink overflow-hidden"
+          class="flex flex-col gap-2 grow shrink"
           value={preferences.remoteAudio.rx.outputDeviceId}
           onChange={(value: string) => {
             if (!value) return;
@@ -144,7 +142,7 @@ function InnerAudioSettings() {
           <SelectContent />
         </Select>
         <Select
-          class="flex flex-col gap-2 grow shrink overflow-hidden"
+          class="flex flex-col gap-2 grow shrink"
           value={preferences.remoteAudio.tx.inputDeviceId}
           onChange={(value: string) => {
             if (!value) return;

--- a/apps/web/src/components/settings/dax-settings.tsx
+++ b/apps/web/src/components/settings/dax-settings.tsx
@@ -135,7 +135,7 @@ function InnerDaxSettings() {
           {/* </Show> */}
           <div class="flex gap-2">
             <Select
-              class="flex flex-col gap-2 grow shrink overflow-hidden"
+              class="flex flex-col gap-2 grow shrink"
               value={preferences.dax.tx.inputDeviceId}
               onChange={(value: string) => {
                 if (!value) return;
@@ -150,14 +150,17 @@ function InnerDaxSettings() {
               )}
             >
               <SelectLabel>Input Device</SelectLabel>
-              <SelectTrigger>
-                <SelectValue class="overflow-hidden text-ellipsis whitespace-nowrap">
-                  {(state) =>
-                    inputs().find((d) => d.deviceId === state.selectedOption())
-                      ?.label || "Select Audio Input"
-                  }
-                </SelectValue>
-              </SelectTrigger>
+              <div class="relative h-10">
+                <SelectTrigger class="absolute">
+                  <SelectValue class="shrink overflow-hidden text-ellipsis whitespace-nowrap">
+                    {(state) =>
+                      inputs().find(
+                        (d) => d.deviceId === state.selectedOption(),
+                      )?.label || "Select Audio Input"
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+              </div>
               <SelectContent />
             </Select>
             <Select<DaxChannelMode>
@@ -266,7 +269,7 @@ function InnerDaxSettings() {
             <CardContent class="flex flex-col gap-4">
               <div class="flex gap-2">
                 <Select
-                  class="flex flex-col gap-2 grow shrink overflow-hidden"
+                  class="flex flex-col gap-2 grow shrink"
                   value={preferences.dax.rx[channel].outputDeviceId}
                   onChange={(value: string) => {
                     if (!value) return;
@@ -292,15 +295,17 @@ function InnerDaxSettings() {
                   }}
                 >
                   <SelectLabel>Output Device</SelectLabel>
-                  <SelectTrigger>
-                    <SelectValue class="overflow-hidden text-ellipsis whitespace-nowrap">
-                      {(state) =>
-                        outputs().find(
-                          (d) => d.deviceId === state.selectedOption(),
-                        )?.label || "Select Audio Output"
-                      }
-                    </SelectValue>
-                  </SelectTrigger>
+                  <div class="w-full h-10 relative">
+                    <SelectTrigger class="absolute">
+                      <SelectValue class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        {(state) =>
+                          outputs().find(
+                            (d) => d.deviceId === state.selectedOption(),
+                          )?.label || "Select Audio Output"
+                        }
+                      </SelectValue>
+                    </SelectTrigger>
+                  </div>
                   <SelectContent />
                 </Select>
                 <Select<DaxChannelMode>

--- a/apps/web/src/components/settings/index.tsx
+++ b/apps/web/src/components/settings/index.tsx
@@ -38,6 +38,7 @@ import { MultiflexSettings } from "./multiflex-settings";
 import { NetworkStats } from "./network-stats";
 import { WaveformSettings } from "./waveform-settings";
 import { Meters } from "./meters";
+import { ProfileSettings } from "./profile-settings";
 
 const tabs = {
   app: AppSettings,
@@ -51,6 +52,7 @@ const tabs = {
   network: NetworkStats,
   waveform: WaveformSettings,
   meters: Meters,
+  profiles: ProfileSettings,
 };
 
 export function Settings() {
@@ -103,6 +105,9 @@ export function Settings() {
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setActiveTab("meters")}>
             Meters
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setActiveTab("profiles")}>
+            Profiles
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/components/settings/profile-settings.tsx
+++ b/apps/web/src/components/settings/profile-settings.tsx
@@ -1,0 +1,418 @@
+import {
+  createEffect,
+  createSignal,
+  For,
+  JSX,
+  Show,
+  splitProps,
+  ValidComponent,
+} from "solid-js";
+
+import useFlexRadio from "~/context/flexradio";
+import { networkQualityLabel } from "~/lib/network-telemetry";
+import { Badge } from "../ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import { Radio } from "@repo/flexlib";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { SimpleSwitch } from "../ui/simple-switch";
+import { Button } from "../ui/button";
+import { TextField, TextFieldInput, TextFieldLabel } from "../ui/text-field";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import { RadioGroup } from "@kobalte/core/radio-group";
+import MaterialSymbolsDeviceReset from "~icons/material-symbols/device-reset";
+import MaterialSymbolsSave from "~icons/material-symbols/save";
+import MaterialSymbolsDelete from "~icons/material-symbols/delete";
+import { ConfirmButton } from "../ui/confirm-button";
+import * as DialogPrimitive from "@kobalte/core/dialog";
+import { createDisclosureState } from "@kobalte/core/primitives/create-disclosure-state";
+
+const LABELS = {
+  global: "Global",
+  mic: "Microphone",
+  tx: "Transmit",
+};
+
+export function CreateProfileDialog(
+  props: DialogPrimitive.DialogRootProps & {
+    radio: Radio;
+    kind: "global" | "mic" | "tx";
+    children?: JSX.Element;
+  },
+) {
+  const [local, rest] = splitProps(props, [
+    "children",
+    "defaultOpen",
+    "kind",
+    "onOpenChange",
+    "open",
+    "radio",
+  ]);
+  const [name, setName] = createSignal("");
+  const disclosureState = createDisclosureState({
+    open: () => local.open,
+    defaultOpen: () => local.defaultOpen,
+    onOpenChange: (isOpen) => local.onOpenChange?.(isOpen),
+  });
+
+  createEffect(() => {
+    if (!disclosureState.isOpen()) setName("");
+  });
+
+  return (
+    <Dialog
+      open={disclosureState.isOpen()}
+      onOpenChange={disclosureState.setIsOpen}
+      {...rest}
+    >
+      {local.children}
+      <DialogContent
+        as="form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const profileName = name();
+          if (!profileName.length) return;
+          const method = {
+            global: "saveGlobalProfile",
+            tx: "createTxProfile",
+            mic: "createMicProfile",
+          }[local.kind];
+
+          local.radio[method](profileName)
+            .then(() => {
+              disclosureState.setIsOpen(false);
+            })
+            .catch(console.error);
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Create {LABELS[props.kind]} Profile</DialogTitle>
+        </DialogHeader>
+        <TextField
+          value={name()}
+          onChange={setName}
+          class="flex flex-col gap-2"
+        >
+          <TextFieldLabel for="profile-name">Profile Name</TextFieldLabel>
+          <TextFieldInput id="profile-name" placeholder="New Profile Name" />
+        </TextField>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => disclosureState.setIsOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={name().length === 0}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GlobalProfiles(props: { radio: Radio }) {
+  const { state } = useFlexRadio();
+
+  return (
+    <Table class="whitespace-nowrap">
+      <TableHeader>
+        <TableRow>
+          <TableHead />
+          <TableHead class="w-full">Name</TableHead>
+          <TableHead>Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <RadioGroup
+        as={TableBody}
+        value={state.status.radio.profileGlobalSelection}
+        onChange={(value) => props.radio.loadGlobalProfile(value)}
+      >
+        <For each={Array.from(state.status.radio.profileGlobalList)}>
+          {(profile) => {
+            return (
+              <RadioGroup.Item as={TableRow} value={profile}>
+                <TableCell>
+                  <RadioGroup.ItemInput />
+                  <RadioGroup.ItemControl class="aspect-square size-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50">
+                    <RadioGroup.ItemIndicator class="flex h-full items-center justify-center ">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="size-2.5 fill-current text-current"
+                      >
+                        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                      </svg>
+                    </RadioGroup.ItemIndicator>
+                  </RadioGroup.ItemControl>
+                </TableCell>
+                <TableCell>{profile}</TableCell>
+                <TableCell class="flex justify-end gap-1">
+                  <ConfirmButton
+                    size="icon"
+                    title="Save"
+                    message={`Update global profile "${profile}" with the current settings?`}
+                    onConfirm={() => props.radio.saveGlobalProfile(profile)}
+                  >
+                    <MaterialSymbolsSave />
+                  </ConfirmButton>
+                  <ConfirmButton
+                    size="icon"
+                    variant="destructive"
+                    title="Delete"
+                    message={`Delete global profile "${profile}"?`}
+                    onConfirm={() => props.radio.deleteGlobalProfile(profile)}
+                  >
+                    <MaterialSymbolsDelete />
+                  </ConfirmButton>
+                </TableCell>
+              </RadioGroup.Item>
+            );
+          }}
+        </For>
+      </RadioGroup>
+    </Table>
+  );
+}
+
+function TxProfiles(props: { radio: Radio }) {
+  const { state } = useFlexRadio();
+
+  return (
+    <Table class="whitespace-nowrap">
+      <TableHeader>
+        <TableRow>
+          <TableHead />
+          <TableHead class="w-full">Name</TableHead>
+          <TableHead>Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <RadioGroup
+        as={TableBody}
+        value={state.status.radio.profileTxSelection}
+        onChange={(value) => props.radio.loadTxProfile(value)}
+      >
+        <For each={Array.from(state.status.radio.profileTxList)}>
+          {(profile) => {
+            return (
+              <RadioGroup.Item as={TableRow} value={profile}>
+                <TableCell>
+                  <RadioGroup.ItemInput />
+                  <RadioGroup.ItemControl class="aspect-square size-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50">
+                    <RadioGroup.ItemIndicator class="flex h-full items-center justify-center ">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="size-2.5 fill-current text-current"
+                      >
+                        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                      </svg>
+                    </RadioGroup.ItemIndicator>
+                  </RadioGroup.ItemControl>
+                </TableCell>
+                <TableCell>{profile}</TableCell>
+                <TableCell class="flex justify-end gap-1">
+                  <ConfirmButton
+                    size="icon"
+                    title="Reset"
+                    message={`Reset transmit profile "${profile}" to default settings?`}
+                    onConfirm={() => props.radio.resetTxProfile(profile)}
+                  >
+                    <MaterialSymbolsDeviceReset />
+                  </ConfirmButton>
+                  <ConfirmButton
+                    disabled={
+                      profile === state.status.radio.profileTxSelection &&
+                      !state.status.radio.profileUnsavedChangesTx
+                    }
+                    size="icon"
+                    title="Save"
+                    message={`Update transmit profile "${profile}" with the current settings?`}
+                    onConfirm={() => props.radio.createTxProfile(profile)}
+                  >
+                    <MaterialSymbolsSave />
+                  </ConfirmButton>
+                  <ConfirmButton
+                    size="icon"
+                    variant="destructive"
+                    title="Delete"
+                    message={`Delete transmit profile "${profile}"?`}
+                    onConfirm={() => props.radio.deleteTxProfile(profile)}
+                  >
+                    <MaterialSymbolsDelete />
+                  </ConfirmButton>
+                </TableCell>
+              </RadioGroup.Item>
+            );
+          }}
+        </For>
+      </RadioGroup>
+    </Table>
+  );
+}
+
+function MicProfiles(props: { radio: Radio }) {
+  const { state } = useFlexRadio();
+
+  return (
+    <Table class="whitespace-nowrap">
+      <TableHeader>
+        <TableRow>
+          <TableHead />
+          <TableHead class="w-full">Name</TableHead>
+          <TableHead>Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <RadioGroup
+        as={TableBody}
+        value={state.status.radio.profileMicSelection}
+        onChange={(value) => props.radio.loadMicProfile(value)}
+      >
+        <For each={Array.from(state.status.radio.profileMicList)}>
+          {(profile) => {
+            return (
+              <RadioGroup.Item as={TableRow} value={profile}>
+                <TableCell>
+                  <RadioGroup.ItemInput />
+                  <RadioGroup.ItemControl class="aspect-square size-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50">
+                    <RadioGroup.ItemIndicator class="flex h-full items-center justify-center ">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="size-2.5 fill-current text-current"
+                      >
+                        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                      </svg>
+                    </RadioGroup.ItemIndicator>
+                  </RadioGroup.ItemControl>
+                </TableCell>
+                <TableCell>{profile}</TableCell>
+                <TableCell class="flex justify-end gap-1">
+                  <ConfirmButton
+                    size="icon"
+                    title="Reset"
+                    message={`Reset microphone profile "${profile}" to default settings?`}
+                    onConfirm={() => props.radio.resetMicProfile(profile)}
+                  >
+                    <MaterialSymbolsDeviceReset />
+                  </ConfirmButton>
+                  <ConfirmButton
+                    disabled={
+                      profile === state.status.radio.profileMicSelection &&
+                      !state.status.radio.profileUnsavedChangesMic
+                    }
+                    size="icon"
+                    title="Save"
+                    message={`Update microphone profile "${profile}" with the current settings?`}
+                    onConfirm={() => props.radio.createMicProfile(profile)}
+                  >
+                    <MaterialSymbolsSave />
+                  </ConfirmButton>
+                  <ConfirmButton
+                    size="icon"
+                    variant="destructive"
+                    title="Delete"
+                    message={`Delete microphone profile "${profile}"?`}
+                    onConfirm={() => props.radio.deleteMicProfile(profile)}
+                  >
+                    <MaterialSymbolsDelete />
+                  </ConfirmButton>
+                </TableCell>
+              </RadioGroup.Item>
+            );
+          }}
+        </For>
+      </RadioGroup>
+    </Table>
+  );
+}
+
+function ProfileSettingsInner(props: { radio: Radio }) {
+  const { state } = useFlexRadio();
+  const [activeTab, setActiveTab] = createSignal<"global" | "mic" | "tx">(
+    "global",
+  );
+
+  return (
+    <>
+      <div class="flex flex-col gap-4 overflow-hidden py-4">
+        <SimpleSwitch
+          label="Enable Profile Auto-Save"
+          checked={state.status.radio.profileAutoSave}
+          onChange={props.radio.setProfileAutoSave}
+        />
+        <Tabs
+          value={activeTab()}
+          onChange={setActiveTab}
+          class=" flex flex-col overflow-hidden"
+        >
+          <TabsList class="grid w-fit grid-cols-3 m-auto">
+            <TabsTrigger value="global">Global</TabsTrigger>
+            <TabsTrigger value="tx">Transmit</TabsTrigger>
+            <TabsTrigger value="mic">Microphone</TabsTrigger>
+          </TabsList>
+          <div class="shrink overflow-auto">
+            <TabsContent value="global">
+              <GlobalProfiles radio={props.radio} />
+            </TabsContent>
+            <TabsContent value="tx">
+              <TxProfiles radio={props.radio} />
+            </TabsContent>
+            <TabsContent value="mic">
+              <MicProfiles radio={props.radio} />
+            </TabsContent>
+          </div>
+        </Tabs>
+      </div>
+      <DialogFooter>
+        <CreateProfileDialog radio={props.radio} kind={activeTab()}>
+          <DialogTrigger as={Button}>Create Profile</DialogTrigger>
+        </CreateProfileDialog>
+      </DialogFooter>
+    </>
+  );
+}
+
+export function ProfileSettings() {
+  const { radio } = useFlexRadio();
+  return (
+    <DialogContent class="translate-y-0 top-1/12 flex max-h-10/12 flex-col overflow-hidden text-sm">
+      <DialogHeader>
+        <DialogTitle>Profile Manager</DialogTitle>
+      </DialogHeader>
+      <Show when={radio()} fallback={<div class="text-sm">Not Connected</div>}>
+        <ProfileSettingsInner radio={radio()} />
+      </Show>
+    </DialogContent>
+  );
+}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -12,6 +12,7 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 const DropdownMenuArrow = DropdownMenuPrimitive.Arrow;
+const DropdownMenuIcon = DropdownMenuPrimitive.Icon;
 
 const DropdownMenu: Component<DropdownMenuPrimitive.DropdownMenuRootProps> = (
   props,
@@ -281,4 +282,5 @@ export {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuArrow,
+  DropdownMenuIcon,
 };

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -42,7 +42,7 @@ const SelectTrigger = <T extends ValidComponent = "button">(
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"
-        class="size-4 opacity-50"
+        class="size-4 opacity-50 shrink-0"
       >
         <path d="M8 9l4 -4l4 4" />
         <path d="M16 15l-4 4l-4 -4" />


### PR DESCRIPTION
## Profile Manager Dialog

<img width="553" height="764" alt="image" src="https://github.com/user-attachments/assets/80fd3193-402c-4f63-bbbc-3e042254bc0a" />

## Panafall Context Menu Profile Management

Adds a new Profiles section in the panafall context menu for saving, creating, or selecting global profiles. The panafall context menu is accessed by right clicking (or long-pressing on touch devices) in the panadapter or waterfall.

<img width="278" height="327" alt="image" src="https://github.com/user-attachments/assets/7af7a171-6694-4a88-a1a9-9288a536014c" />


## Radio Sidebar Profile Management
Adds dropdown menus next to the TX and Mic profile selections in the radio sidebar for profile management, along with a new indicator when a profile has unsaved changes.

<img width="261" height="241" alt="image" src="https://github.com/user-attachments/assets/b5f503b6-f673-4bd5-b97a-f4d6dcc0e9d0" />

<img width="257" height="232" alt="image" src="https://github.com/user-attachments/assets/43173837-515e-43fa-9dff-06a565d79d34" />

