### PR TITLE
Global TNF toggle

### DIFF
--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -490,6 +490,15 @@ export function Panafall(props: { index: number }) {
                       <ContextMenuSeparator />
                       <ContextMenuGroup>
                         <ContextMenuCheckboxItem
+                          checked={state.status.radio.tnfEnabled}
+                          onChange={(checked) => {
+                            radio().setTnfEnabled(checked);
+                          }}
+                        >
+                          Globally Enable TNFs
+                        </ContextMenuCheckboxItem>
+                        <ContextMenuSeparator />
+                        <ContextMenuCheckboxItem
                           checked={preferences.showTuningGuide}
                           onChange={(checked) => {
                             setPreferences("showTuningGuide", checked);

--- a/apps/web/src/components/panafall/tnf.tsx
+++ b/apps/web/src/components/panafall/tnf.tsx
@@ -41,7 +41,7 @@ function quantizeBandwidth(bandwidthMHz: number) {
 }
 
 export function Tnf(props: { tnf: TnfState; pan: PanadapterState }) {
-  const { radio } = useFlexRadio();
+  const { radio, state } = useFlexRadio();
   const { freqToX, mhzToPx, pxToMHz } = usePanafall();
   const [dragState, setDragState] = createStore({
     down: false,
@@ -93,9 +93,11 @@ export function Tnf(props: { tnf: TnfState; pan: PanadapterState }) {
     <div
       class="absolute left-(--tnf-offset) -translate-x-1/2 inset-y-0 w-(--tnf-width) pointer-events-auto cursor-move"
       style={{
-        "--tnf-color": props.tnf.permanent
-          ? "var(--color-green-500)"
-          : "var(--color-yellow-500)",
+        "--tnf-color": state.status.radio.tnfEnabled
+          ? props.tnf.permanent
+            ? "var(--color-green-500)"
+            : "var(--color-yellow-500)"
+          : "var(--color-foreground)",
         "--tnf-offset": `${freqToX(props.tnf.frequencyMHz)}px`,
         "--tnf-width": `${Math.max(1, Math.round(mhzToPx(props.tnf.bandwidthMHz))) + 2}px`,
         "--tnf-depth": props.tnf.depth,


### PR DESCRIPTION
## Globally toggle TNF

Adds a global TNF toggle to the panafall context menu

<img width="266" height="324" alt="image" src="https://github.com/user-attachments/assets/332f986c-cc0b-4168-a5ff-0c35c8538a19" />

## TNF rendering indicates global state

TNFs are now rendered with a distinct color when globally disabled.

<img width="350" height="241" alt="image" src="https://github.com/user-attachments/assets/662e57e6-3b55-454a-9ebe-7f0bfe470a14" />