### PR TITLE
Add TNF enabled as a mappable control

### DIFF
--- a/apps/web/src/context/controls.tsx
+++ b/apps/web/src/context/controls.tsx
@@ -1651,6 +1651,21 @@ export const CONTROL_DEFINITIONS = [
     },
   }),
 
+  defineControl<BooleanControlAction<"radio.tnf.enabled">>({
+    target: "radio.tnf.enabled",
+    label: "Radio TNF Enabled",
+    scope: "radio",
+    ops: ["toggle", "set"],
+    editor: { kind: "boolean" },
+    execute(ctx, action) {
+      const radioController = ctx.radio();
+      if (!radioController) return;
+      radioController.setTnfEnabled(
+        resolveBooleanAction(action, radioController.tnfEnabled),
+      );
+    },
+  }),
+
   defineControl<BooleanControlAction<"radio.txMonitor.enabled">>({
     target: "radio.txMonitor.enabled",
     label: "Radio TX Monitor Enabled",


### PR DESCRIPTION
## Adds TNF Enabled as a mappable target control

<img width="455" height="243" alt="image" src="https://github.com/user-attachments/assets/2e299232-1cfb-479e-a42b-aca75d4378a1" />
