### PR TITLE
Version Reporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+apps/server/internal/version/version.go export-subst

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
     flags:
       - -tags=release
     ldflags:
-      - -s -w
+      - -s -w -X github.com/daveisadork/solid-sdr/apps/server/internal/version.Version={{.Tag}}
     goos:
       - linux
       - darwin

--- a/apps/server/cmd/bridge/main.go
+++ b/apps/server/cmd/bridge/main.go
@@ -14,9 +14,16 @@ import (
 	"github.com/daveisadork/solid-sdr/apps/server/internal/discovery"
 	"github.com/daveisadork/solid-sdr/apps/server/internal/rtc"
 	"github.com/daveisadork/solid-sdr/apps/server/internal/static"
+	"github.com/daveisadork/solid-sdr/apps/server/internal/version"
 )
 
 func main() {
+	v := version.Resolve()
+
+	if isVersionFlag(v) {
+		return
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("config error: %v", err)
@@ -71,7 +78,7 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("listening on %s", addr)
+		log.Printf("solid-sdr-server %s listening on %s", v, addr)
 
 		err := srv.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -88,6 +95,18 @@ func main() {
 	defer cancel()
 
 	_ = srv.Shutdown(ctx)
+}
+
+func isVersionFlag(v string) bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "--version" || arg == "-version" || arg == "-V" {
+			_, _ = fmt.Fprintf(os.Stdout, "solid-sdr-server %s\n", v)
+
+			return true
+		}
+	}
+
+	return false
 }
 
 func withCOI(next http.Handler) http.Handler {

--- a/apps/server/cmd/bridge/main.go
+++ b/apps/server/cmd/bridge/main.go
@@ -45,6 +45,7 @@ func main() {
 		ICEPortEnd:   cfg.ICEPortEnd,
 		STUN:         cfg.StunURLs,
 		NAT1To1IPs:   cfg.NAT1To1IPs,
+		Version:      v,
 	})
 
 	// ---- HTTP mux ----

--- a/apps/server/internal/config/config.go
+++ b/apps/server/internal/config/config.go
@@ -68,13 +68,14 @@ func Load() (Config, error) {
 	fs.String("config", "", "Path to optional config file")
 
 	// Usage
-	fs.Usage = func() {
+	usage := func() {
 		fmt.Fprintf(os.Stderr, `solid-sdr-server
 
 Usage:
   %s [flags]
 
 Flags:
+  -V, --version         Print version and exit
 `, os.Args[0])
 		fs.PrintDefaults()
 		fmt.Fprintf(os.Stderr, `
@@ -89,8 +90,12 @@ Config file:
   Or place solid-sdr-server.yaml/json/toml in current directory
 `)
 	}
+	fs.Usage = usage
 
 	pflag.CommandLine.AddFlagSet(fs)
+	pflag.CommandLine.Usage = usage
+	pflag.Usage = usage
+
 	pflag.Parse()
 
 	// Viper setup

--- a/apps/server/internal/rtc/server.go
+++ b/apps/server/internal/rtc/server.go
@@ -18,12 +18,14 @@ type Options struct {
 	ICEPortEnd   uint16
 	STUN         []string
 	NAT1To1IPs   []string
+	Version      string
 }
 
 type Server struct {
 	disco      *discovery.Service
 	api        *webrtc.API
 	iceServers []webrtc.ICEServer
+	version    string
 }
 
 func New(disco *discovery.Service, opt Options) *Server {
@@ -72,7 +74,7 @@ func New(disco *discovery.Service, opt Options) *Server {
 		iceServers = append(iceServers, webrtc.ICEServer{URLs: opt.STUN})
 	}
 
-	return &Server{disco: disco, api: api, iceServers: iceServers}
+	return &Server{disco: disco, api: api, iceServers: iceServers, version: opt.Version}
 }
 
 var upgrader = websocket.Upgrader{ //nolint:gochecknoglobals
@@ -91,12 +93,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = ws.Close() }()
 
 	clientIP := clientIPFromRequest(r)
-	log.Printf("[rtc] new connection from %s", clientIP)
 
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	cs := newClientSession(s, ws, cancel)
+	cs := newClientSession(s, ws, cancel, clientIP)
+	cs.trySend(mustEncode(typeVersion, versionPayload{Version: s.version}))
 	cs.serve(ctx)
 }
 

--- a/apps/server/internal/rtc/session.go
+++ b/apps/server/internal/rtc/session.go
@@ -23,6 +23,7 @@ const (
 	typeNetworkDiagnostics = "networkDiagnostics"
 	typePing               = "ping"
 	typePong               = "pong"
+	typeVersion            = "version"
 )
 
 type message struct {
@@ -33,6 +34,10 @@ type message struct {
 type errorPayload struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+type versionPayload struct {
+	Version string `json:"version"`
 }
 
 func encode(msgType string, payload any) (message, error) {
@@ -59,18 +64,20 @@ type clientSession struct {
 	cancel     context.CancelFunc
 	send       chan message
 	audioTrack *webrtc.TrackLocalStaticSample
+	clientIP   string
 
 	mu    sync.Mutex
 	pc    *webrtc.PeerConnection
 	radio *radioConn
 }
 
-func newClientSession(srv *Server, ws *websocket.Conn, cancel context.CancelFunc) *clientSession {
+func newClientSession(srv *Server, ws *websocket.Conn, cancel context.CancelFunc, clientIP string) *clientSession {
 	return &clientSession{
-		srv:    srv,
-		ws:     ws,
-		cancel: cancel,
-		send:   make(chan message, 64),
+		srv:      srv,
+		ws:       ws,
+		cancel:   cancel,
+		send:     make(chan message, 64),
+		clientIP: clientIP,
 	}
 }
 
@@ -129,9 +136,22 @@ func (cs *clientSession) dispatch(ctx context.Context, msg message) {
 		cs.handleICE(msg.Payload)
 	case typePing:
 		cs.trySend(mustEncode(typePong, nil))
+	case typeVersion:
+		cs.handleVersion(msg.Payload)
 	default:
 		log.Printf("[rtc] unknown message type: %q", msg.Type)
 	}
+}
+
+func (cs *clientSession) handleVersion(raw json.RawMessage) {
+	var p versionPayload
+
+	err := json.Unmarshal(raw, &p)
+	if err != nil {
+		return
+	}
+
+	log.Printf("[rtc] client %s connected with version %s", cs.clientIP, p.Version)
 }
 
 func (cs *clientSession) reportServerToRadioDiagnostics(
@@ -246,8 +266,6 @@ func (cs *clientSession) setupPeerConnection(ctx context.Context) {
 		cs.trySend(mustEncode(typeICE, c.ToJSON()))
 	})
 	cs.pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
-		log.Printf("[rtc] connection state: %s", state)
-
 		if state == webrtc.PeerConnectionStateFailed || state == webrtc.PeerConnectionStateClosed {
 			cs.cancel()
 			_ = cs.pc.Close()

--- a/apps/server/internal/version/version.go
+++ b/apps/server/internal/version/version.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"context"
+	"os/exec"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+// Version is overridden at build time by GoReleaser via -X ldflags.
+var Version = "dev" //nolint:gochecknoglobals
+
+// GitDescribe is substituted by git archive via export-subst (.gitattributes).
+// When building from a git checkout the literal $Format:...$ marker is retained.
+const GitDescribe = "$Format:%(describe:tags=true)$"
+
+// Resolve returns the most informative version string available.
+// Priority: ldflags → export-subst → git describe --tags → vcs hash → "dev".
+func Resolve() string {
+	if Version != "dev" {
+		return Version
+	}
+
+	if !strings.HasPrefix(GitDescribe, "$Format:") {
+		return GitDescribe
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "git", "describe", "--tags").Output()
+	if err == nil {
+		if v := strings.TrimSpace(string(out)); v != "" {
+			return v
+		}
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && len(s.Value) >= 7 {
+				return "dev+" + s.Value[:7]
+			}
+		}
+	}
+
+	return "dev"
+}

--- a/apps/web/src/components/settings/app-settings.tsx
+++ b/apps/web/src/components/settings/app-settings.tsx
@@ -4,6 +4,8 @@ import {
   PeakStyle,
   usePreferences,
 } from "../../context/preferences";
+import { APP_VERSION } from "~/lib/version";
+import { InfoItem } from "./common";
 import {
   Card,
   CardContent,
@@ -110,6 +112,14 @@ export function AppSettings() {
         class="relative flex flex-col gap-4 text-sm overflow-y-auto shrink"
         style={{ "scrollbar-width": "thin" }}
       >
+        <Card class="bg-transparent">
+          <CardHeader>
+            <CardTitle>About</CardTitle>
+          </CardHeader>
+          <CardContent class="flex flex-col gap-2 text-sm">
+            <InfoItem label="App Version" value={APP_VERSION} />
+          </CardContent>
+        </Card>
         <Card class="bg-transparent">
           <CardHeader>
             <CardTitle>Station</CardTitle>

--- a/apps/web/src/components/settings/app-settings.tsx
+++ b/apps/web/src/components/settings/app-settings.tsx
@@ -40,6 +40,7 @@ import {
   TextFieldLabel,
 } from "../ui/text-field";
 import useFlexRadio from "~/context/flexradio";
+import { useRtc } from "~/context/rtc";
 import { DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { SimpleSlider } from "../ui/simple-slider";
 import Upload from "~icons/material-symbols/upload";
@@ -62,6 +63,7 @@ export function AppSettings() {
   const { preferences, setPreferences } = usePreferences();
   const { setColorMode } = useColorMode();
   const { radio } = useFlexRadio();
+  const { serverVersion } = useRtc();
 
   const [importFile, setImportFile] = createSignal<File>();
 
@@ -118,6 +120,7 @@ export function AppSettings() {
           </CardHeader>
           <CardContent class="flex flex-col gap-2 text-sm">
             <InfoItem label="App Version" value={APP_VERSION} />
+            <InfoItem label="Server Version" value={serverVersion() ?? "—"} />
           </CardContent>
         </Card>
         <Card class="bg-transparent">

--- a/apps/web/src/components/settings/common.tsx
+++ b/apps/web/src/components/settings/common.tsx
@@ -3,8 +3,8 @@ import { JSXElement, Show } from "solid-js";
 export function InfoItem(props: { label: JSXElement; value: JSXElement }) {
   return (
     <Show when={props.value !== undefined}>
-      <div class="flex">
-        <div class="grow">{props.label}:</div>
+      <div class="flex justify-between items-center">
+        <span>{props.label}:</span>
         <span>{props.value}</span>
       </div>
     </Show>

--- a/apps/web/src/context/rtc.tsx
+++ b/apps/web/src/context/rtc.tsx
@@ -8,6 +8,7 @@ import {
   batch,
 } from "solid-js";
 import type { Accessor, Setter } from "solid-js";
+import { APP_VERSION } from "~/lib/version";
 import {
   createReconnectingWS,
   createWSState,
@@ -35,6 +36,7 @@ type RtcContextValue = {
   setRemoteAudioTxTrack: Setter<MediaStreamTrack>;
   signalingWs: ReconnectingWebSocket;
   signalingWsState: Accessor<0 | 1 | 2 | 3>;
+  serverVersion: Accessor<string | null>;
 };
 
 type SignalingMessage =
@@ -42,7 +44,8 @@ type SignalingMessage =
   | { type: "ice"; payload: RTCIceCandidateInit }
   | { type: "error"; payload: { code: string; message: string } }
   | { type: "ping"; payload: null }
-  | { type: "pong"; payload: null };
+  | { type: "pong"; payload: null }
+  | { type: "version"; payload: { version: string } };
 
 export const RtcProvider: ParentComponent = (props) => {
   const [rtcState, setRtcState] = createStore<RtcState>({
@@ -53,6 +56,7 @@ export const RtcProvider: ParentComponent = (props) => {
   });
   const [peerConnection, setPeerConnection] =
     createSignal<RTCPeerConnection | null>(null);
+  const [serverVersion, setServerVersion] = createSignal<string | null>(null);
   const [audioTransceiver, setAudioTransceiver] =
     createSignal<RTCRtpTransceiver | null>(null);
   const [remoteAudioRxStream, setRemoteAudioRxStream] =
@@ -133,7 +137,17 @@ export const RtcProvider: ParentComponent = (props) => {
         console.error(new Error(`${payload.code}: ${payload.message}`));
         break;
       }
+      case "version": {
+        setServerVersion(payload.version);
+        break;
+      }
     }
+  };
+
+  const onOpen = () => {
+    signalingWs.send(
+      JSON.stringify({ type: "version", payload: { version: APP_VERSION } }),
+    );
   };
 
   function onRtcStateChange(this: RTCPeerConnection) {
@@ -153,8 +167,10 @@ export const RtcProvider: ParentComponent = (props) => {
 
   createEffect(() => {
     signalingWs.addEventListener("message", onMessage);
+    signalingWs.addEventListener("open", onOpen);
     onCleanup(() => {
       signalingWs.removeEventListener("message", onMessage);
+      signalingWs.removeEventListener("open", onOpen);
     });
   });
 
@@ -162,6 +178,7 @@ export const RtcProvider: ParentComponent = (props) => {
     batch(() => {
       if (signalingWsState() !== WebSocket.OPEN) {
         setPeerConnection(null);
+        setServerVersion(null);
         return;
       }
 
@@ -226,6 +243,7 @@ export const RtcProvider: ParentComponent = (props) => {
         remoteAudioRxStream,
         setRemoteAudioTxTrack,
         signalingWsState,
+        serverVersion,
       }}
     >
       {props.children}

--- a/apps/web/src/lib/version.ts
+++ b/apps/web/src/lib/version.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+export const APP_VERSION: string = __APP_VERSION__;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,5 @@
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
@@ -5,7 +7,21 @@ import solidPlugin from "vite-plugin-solid";
 import Icons from "unplugin-icons/vite";
 import { visualizer } from "rollup-plugin-visualizer";
 
+function getVersion(): string {
+  try {
+    return execSync("git describe --tags", { encoding: "utf8" }).trim();
+  } catch {
+    const pkg = JSON.parse(readFileSync("./package.json", "utf8")) as {
+      version: string;
+    };
+    return `v${pkg.version}`;
+  }
+}
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(getVersion()),
+  },
   plugins: [
     solidPlugin(),
     tailwindcss(),


### PR DESCRIPTION
## Version Reporting

The server gains a new `--version` flag. Server log output now includes both the server version, and version of connected clients:

```
2026/05/21 10:54:41 solid-sdr-server v0.1.5-4-g838c0c9 listening on :8080
2026/05/21 10:54:43 [rtc] client ::1 connected with version v0.1.5-2-g02606cb
```

The App Settings dialog gains a new About section that reports both the client and server versions:

<img width="476" height="158" alt="image" src="https://github.com/user-attachments/assets/b9a061c4-55f1-4345-968b-502c61a9ae56" />
