### PR TITLE
Parsing cleanup

### DIFF
--- a/apps/web/src/components/settings/memory-settings.tsx
+++ b/apps/web/src/components/settings/memory-settings.tsx
@@ -197,7 +197,7 @@ function MemorySettingsInner() {
       cell: (props) => (
         <SelectPrimitive.Root
           options={modeList()}
-          value={props.row.original.mode}
+          value={props.row.original.mode?.trim()}
           onChange={(value?: string) => {
             if (!value || value == props.row.original.mode) return;
             radio().memory(props.row.original.id)?.setMode(value);
@@ -208,9 +208,11 @@ function MemorySettingsInner() {
             );
           }}
         >
-          <SelectPrimitive.Trigger>
+          <SelectPrimitive.Trigger class="w-full">
             <SelectPrimitive.Value<string>>
-              {(state) => state.selectedOption()}
+              {(state) =>
+                state.selectedOption() ?? `${props.row.original.mode}⚠`
+              }
             </SelectPrimitive.Value>
           </SelectPrimitive.Trigger>
 

--- a/apps/web/src/components/settings/memory-settings.tsx
+++ b/apps/web/src/components/settings/memory-settings.tsx
@@ -208,10 +208,15 @@ function MemorySettingsInner() {
             );
           }}
         >
-          <SelectPrimitive.Trigger class="w-full">
+          <SelectPrimitive.Trigger class="w-full text-left">
             <SelectPrimitive.Value<string>>
               {(state) =>
-                state.selectedOption() ?? `${props.row.original.mode}⚠`
+                state.selectedOption() ?? (
+                  <>
+                    {props.row.original.mode}
+                    <span class="text-warning-foreground">⚠</span>
+                  </>
+                )
               }
             </SelectPrimitive.Value>
           </SelectPrimitive.Trigger>

--- a/apps/web/src/context/flexradio.tsx
+++ b/apps/web/src/context/flexradio.tsx
@@ -421,6 +421,8 @@ export const FlexRadioProvider: ParentComponent = (props) => {
   };
 
   const handleFlexMessage = (message: FlexWireMessage) => {
+    if (message.raw.includes("memory") || message.raw.includes("waveform"))
+      console.log(JSON.stringify(message, null, 2));
     switch (message.kind) {
       case "notice":
         handleNoticePayload(message.raw);

--- a/apps/web/src/context/flexradio.tsx
+++ b/apps/web/src/context/flexradio.tsx
@@ -421,8 +421,6 @@ export const FlexRadioProvider: ParentComponent = (props) => {
   };
 
   const handleFlexMessage = (message: FlexWireMessage) => {
-    if (message.raw.includes("memory") || message.raw.includes("waveform"))
-      console.log(JSON.stringify(message, null, 2));
     switch (message.kind) {
       case "notice":
         handleNoticePayload(message.raw);

--- a/apps/web/src/context/flexradio.tsx
+++ b/apps/web/src/context/flexradio.tsx
@@ -528,9 +528,9 @@ export const FlexRadioProvider: ParentComponent = (props) => {
       await radio.connect({
         clientInfo: {
           isGui: true,
-          program: "SolidSDR Web",
+          program: "SolidSDR",
           guiClientId: preferences.guiClientId,
-          station: preferences.stationName.replaceAll(/ /g, "\u007f"),
+          station: preferences.stationName,
         },
       });
     } catch (error) {

--- a/packages/flexlib/src/flex/gui-client.ts
+++ b/packages/flexlib/src/flex/gui-client.ts
@@ -36,9 +36,9 @@ export function parseDiscoveredGuiClients(
         clientHandle,
         clientHandleInt,
         program: normalizeToken(programs[index]),
-        station: normalizeStation(stations[index]),
-        host: normalizeStation(hosts[index]),
-        ip: normalizeStation(ips[index]),
+        station: normalizeToken(stations[index]),
+        host: normalizeToken(hosts[index]),
+        ip: normalizeToken(ips[index]),
         isLocalPtt: false,
       }),
     );
@@ -60,12 +60,6 @@ function parseClientHandle(value: string | undefined): number | undefined {
 
 function normalizeToken(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const trimmed = value.trim();
+  const trimmed = value.replace(/\u007f/g, " ").trim();
   return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function normalizeStation(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  const replaced = value.replace(/\u007f/g, " ");
-  return normalizeToken(replaced);
 }

--- a/packages/flexlib/src/flex/memory.ts
+++ b/packages/flexlib/src/flex/memory.ts
@@ -24,8 +24,9 @@ export interface MemoryControllerEvents {
  * update settings. Each setter sends the appropriate `memory set` command
  * to the radio and optimistically patches the local store.
  */
-export interface MemoryController
-  extends Readonly<Omit<MemorySnapshot, "raw">> {
+export interface MemoryController extends Readonly<
+  Omit<MemorySnapshot, "raw">
+> {
   /** Returns the current snapshot of this memory's state. */
   snapshot(): MemorySnapshot;
 
@@ -145,15 +146,15 @@ export class MemoryControllerImpl implements MemoryController {
   }
 
   async setOwner(owner: string): Promise<void> {
-    await this.sendSet({ owner: owner.replace(/ /g, "\u007f") });
+    await this.sendSet({ owner });
   }
 
   async setGroup(group: string): Promise<void> {
-    await this.sendSet({ group: group.replace(/ /g, "\u007f") });
+    await this.sendSet({ group });
   }
 
   async setName(name: string): Promise<void> {
-    await this.sendSet({ name: name.replace(/ /g, "\u007f") });
+    await this.sendSet({ name });
   }
 
   async setFrequency(frequencyMHz: number): Promise<void> {
@@ -240,7 +241,7 @@ export class MemoryControllerImpl implements MemoryController {
 
   private async sendSet(entries: Record<string, string>): Promise<void> {
     const parts = Object.entries(entries).map(
-      ([key, value]) => `${key}=${value}`,
+      ([key, value]) => `${key}=${value.replace(/ /g, "\u007f")}`,
     );
     const change = this.radio.getStore().patchMemory(this.id, entries);
     if (change) this.radio.applyStateChange(change);

--- a/packages/flexlib/src/flex/protocol.ts
+++ b/packages/flexlib/src/flex/protocol.ts
@@ -47,10 +47,9 @@ export interface FlexNoticeMessage {
   readonly kind: "notice";
   readonly raw: string;
   readonly timestamp: number;
-  readonly sequence?: number;
+  readonly code: number;
   readonly severity: FlexNoticeSeverity;
   readonly text: string;
-  readonly metadata?: Readonly<Record<string, string>>;
 }
 
 export interface FlexUnknownMessage {
@@ -211,31 +210,23 @@ function parseNotice(
   const { header, body } = splitHeader(line);
   if (body === undefined) return undefined;
 
-  const parts = body.split("|");
-  const sequence = safeParseInt(header);
-  const severityToken = parts[0]?.trim().toLowerCase();
-  const text = parts[1]?.trim() ?? "";
-  const metadataSegment = parts[2];
+  const code = parseReplyCode(header);
+  if (code === undefined) return { kind: "unknown", raw: line, timestamp };
 
-  if (!severityToken) {
-    return {
-      kind: "unknown",
-      raw: line,
-      timestamp,
-    };
-  }
-
-  const severity = normalizeSeverity(severityToken);
-  const metadata = metadataSegment ? parseMetadata(metadataSegment) : undefined;
+  const severityBits = (code >>> 24) & 0x3;
+  let severity: FlexNoticeSeverity;
+  if (severityBits === 1) severity = "warning";
+  else if (severityBits === 2) severity = "error";
+  else if (severityBits === 3) severity = "fatal";
+  else severity = "info";
 
   return {
     kind: "notice",
     raw: line,
     timestamp,
-    sequence: sequence ?? undefined,
+    code,
     severity,
-    text,
-    metadata,
+    text: body,
   };
 }
 
@@ -264,12 +255,6 @@ function parseReplyCode(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function normalizeSeverity(token: string): FlexNoticeSeverity {
-  if (token === "warn" || token === "warning") return "warning";
-  if (token === "err" || token === "error") return "error";
-  if (token === "fatal") return "fatal";
-  return "info";
-}
 
 function parseAttributes(
   source: string,
@@ -391,14 +376,3 @@ function normalizeStatusAttributeValue(value: string): string {
   return v.replace(/\u007f/g, " ").trim();
 }
 
-function parseMetadata(segment: string): Record<string, string> {
-  const attributes = Object.create(null) as Record<string, string>;
-  for (const item of segment.split(",")) {
-    const equals = item.indexOf("=");
-    if (equals === -1) continue;
-    const key = item.slice(0, equals).trim();
-    const value = item.slice(equals + 1).trim();
-    if (key) attributes[key] = value;
-  }
-  return attributes;
-}

--- a/packages/flexlib/src/flex/protocol.ts
+++ b/packages/flexlib/src/flex/protocol.ts
@@ -384,10 +384,11 @@ function parseSpaceSeparatedAttributes(
 const ESCAPED_STATUS_QUOTE = /\\(["\\])/g;
 
 function normalizeStatusAttributeValue(value: string): string {
-  if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
-    return value.slice(1, -1).replace(ESCAPED_STATUS_QUOTE, "$1");
+  let v = value;
+  if (v.startsWith('"') && v.endsWith('"') && v.length >= 2) {
+    v = v.slice(1, -1).replace(ESCAPED_STATUS_QUOTE, "$1");
   }
-  return value;
+  return v.replace(/\u007f/g, " ").trim();
 }
 
 function parseMetadata(segment: string): Record<string, string> {

--- a/packages/flexlib/src/flex/radio-core.ts
+++ b/packages/flexlib/src/flex/radio-core.ts
@@ -352,15 +352,20 @@ const DEFAULT_HANDSHAKE_COMMANDS: readonly string[] = [
   "sub license all",
   "sub usb_cable all",
   "sub tnf all",
-  "sub spot all",
   "sub display_marker all",
+  "sub spot all",
   "sub filt_preset all",
   "sub rapidm all",
   "sub ale all",
   "sub log_manager",
   "sub radio all",
+  "sub codec all",
   "sub apd all",
   "sub dvk all",
+  "sub ha_api amplifier",
+  "sub ha_api fault",
+  "sub navtex all",
+  "sub filt_preset all",
   "sub waveform all",
   "keepalive enable",
 ];
@@ -2678,7 +2683,12 @@ class RadioImpl {
     this.pendingCommands.delete(reply.sequence);
     if (entry.timeoutHandle) clearTimeout(entry.timeoutHandle);
 
-    const accepted = reply.level === "success" || reply.level === "info";
+    // SL_RESP_UNKNOWN (0x50001000): firmware ran the command but forgot to close
+    // the response loop — treat as accepted since the change was applied.
+    const accepted =
+      reply.level === "success" ||
+      reply.level === "info" ||
+      reply.code === 0x50001000;
     entry.resolve({
       sequence: reply.sequence,
       accepted,
@@ -2858,7 +2868,7 @@ class RadioImpl {
 
     const stationName = info.station;
     if (stationName) {
-      await this.command(`client station ${stationName}`).catch(() => {});
+      await this.setClientStationName(stationName).catch(() => {});
     }
 
     this.emitProgress("sync", "complete");

--- a/packages/flexlib/src/flex/response-codes.ts
+++ b/packages/flexlib/src/flex/response-codes.ts
@@ -169,7 +169,7 @@ const BUILTIN_RESPONSE_CODES: ReadonlyArray<[number, string]> = [
   [0x500000a1, "CWX unterminated inline command"],
   [0x500000a2, "CWX invalid inline command"],
   [0x500000a3, "Invalid subscription"],
-  [0x50001000, "Unknown response from radio"],
+  [0x50001000, "Command processed without explicit reply"],
   [0x50001001, "MySQL connection failure"],
   [0x50001002, "MySQL login failure"],
   [0x50001003, "MySQL not connected"],

--- a/packages/flexlib/src/flex/state/apd.ts
+++ b/packages/flexlib/src/flex/state/apd.ts
@@ -171,7 +171,7 @@ function applySamplerAttributes(
   partial: Mutable<Partial<ApdSnapshot>>,
   previous?: ApdSnapshot,
 ): void {
-  const txAntenna = attributes["tx_ant"]?.trim().toUpperCase();
+  const txAntenna = attributes["tx_ant"]?.toUpperCase();
   if (!txAntenna) return;
 
   const samplerState = resolveSamplerState(txAntenna, previous);
@@ -253,7 +253,7 @@ function normalizeSelectedSamplerPort(
   available: readonly string[],
   enforceAvailableList: boolean,
 ): string {
-  const normalized = rawValue?.trim().toUpperCase();
+  const normalized = rawValue?.toUpperCase();
   if (!normalized || normalized === "INVALID") return DEFAULT_SAMPLER_PORT;
   if (!enforceAvailableList) return normalized;
   return available.includes(normalized) ? normalized : DEFAULT_SAMPLER_PORT;

--- a/packages/flexlib/src/flex/state/display-marker.ts
+++ b/packages/flexlib/src/flex/state/display-marker.ts
@@ -55,7 +55,7 @@ export function createDisplayMarkerSnapshot(
         // Identity is resolved before snapshot creation.
         break;
       case "label":
-        partial.label = value.replace(/\u007f/g, " ");
+        partial.label = value;
         break;
       case "start_freq": {
         const parsed = parseFloatSafe(value);
@@ -78,9 +78,6 @@ export function createDisplayMarkerSnapshot(
         else logParseError("display_marker", key, value);
         break;
       }
-      case "removed":
-        // Lifecycle-only flag handled by the store.
-        break;
       default:
         logUnknownAttribute("display_marker", key, value);
         break;

--- a/packages/flexlib/src/flex/state/feature-license.ts
+++ b/packages/flexlib/src/flex/state/feature-license.ts
@@ -133,7 +133,7 @@ function applySubscriptionAttributes(
   partial: Mutable<Partial<FeatureLicenseSnapshot>>,
   previous?: FeatureLicenseSnapshot,
 ): void {
-  const name = attributes["name"]?.trim().toLowerCase();
+  const name = attributes["name"]?.toLowerCase();
   if (!name) {
     logParseError("license", "subscription.name", attributes["name"] ?? "");
     return;
@@ -212,7 +212,7 @@ function parseExpiration(value: string | undefined): Date | undefined {
 
 function normalizeReason(value: string | undefined): FeatureLicenseReason {
   if (!value) return "unknown";
-  const normalized = value.trim().toLowerCase();
+  const normalized = value.toLowerCase();
   if (
     normalized === "license_file" ||
     normalized === "plus" ||

--- a/packages/flexlib/src/flex/state/gui-client.ts
+++ b/packages/flexlib/src/flex/state/gui-client.ts
@@ -50,18 +50,12 @@ export function createGuiClientSnapshot(
   for (const [key, value] of Object.entries(attributes)) {
     switch (key) {
       case "client_id": {
-        const trimmed = value.trim();
-        partial.clientId = trimmed.length > 0 ? trimmed : undefined;
+        partial.clientId = value.length > 0 ? value : undefined;
         break;
       }
-      case "program": {
-        const trimmed = value.trim();
-        partial.program = trimmed.length > 0 ? trimmed : undefined;
-        break;
-      }
+      case "program":
       case "station": {
-        const normalized = value.replace(/\u007f/g, " ").trim();
-        partial.station = normalized.length > 0 ? normalized : undefined;
+        partial[key] = value.length > 0 ? value : undefined;
         break;
       }
       case "local_ptt":

--- a/packages/flexlib/src/flex/state/index.ts
+++ b/packages/flexlib/src/flex/state/index.ts
@@ -1881,7 +1881,7 @@ export function createRadioStateStore(
   function handleContainerWaveform(
     message: FlexStatusMessage,
   ): RadioStateChange[] {
-    const name = message.attributes["name"]?.replace(/\u007f/g, " ").trim();
+    const { name, version } = message.attributes;
     if (!name) {
       return [
         {
@@ -1893,8 +1893,6 @@ export function createRadioStateStore(
       ];
     }
 
-    const version =
-      message.attributes["version"]?.replace(/\u007f/g, " ").trim() ?? "";
     const id = createWaveformId(name, version, true);
     const changes: RadioStateChange[] = [];
     const removed = isMarkedDeleted(message);

--- a/packages/flexlib/src/flex/state/index.ts
+++ b/packages/flexlib/src/flex/state/index.ts
@@ -1067,7 +1067,7 @@ export function createRadioStateStore(
     }
 
     if (action === "connected") {
-      const clientIdAttr = message.attributes["client_id"]?.trim();
+      const clientIdAttr = message.attributes["client_id"];
       if (!clientIdAttr) {
         return [
           {

--- a/packages/flexlib/src/flex/state/memory.ts
+++ b/packages/flexlib/src/flex/state/memory.ts
@@ -46,13 +46,13 @@ export function createMemorySnapshot(
   for (const [key, value] of Object.entries(attributes)) {
     switch (key) {
       case "owner":
-        partial.owner = value.replace(/\u007f/g, " ");
+        partial.owner = value;
         break;
       case "group":
-        partial.group = value.replace(/\u007f/g, " ");
+        partial.group = value;
         break;
       case "name":
-        partial.name = value.replace(/\u007f/g, " ");
+        partial.name = value;
         break;
       case "freq": {
         const parsed = parseMegahertz(value);

--- a/packages/flexlib/src/flex/state/meter.ts
+++ b/packages/flexlib/src/flex/state/meter.ts
@@ -56,9 +56,7 @@ export function parseMeterUnits(
   fallback?: MeterUnits,
 ): MeterUnits {
   if (!value) return fallback ?? "none";
-  const trimmed = value.trim();
-  if (trimmed === "") return fallback ?? "none";
-  const normalized = trimmed.toLowerCase() === "none" ? "none" : trimmed;
+  const normalized = value.toLowerCase() === "none" ? "none" : value;
   const known = KNOWN_METER_UNITS.find((unit) => unit === normalized);
   if (known) return known;
   return normalized as MeterUnits;

--- a/packages/flexlib/src/flex/state/radio.ts
+++ b/packages/flexlib/src/flex/state/radio.ts
@@ -1384,12 +1384,6 @@ type RadioContextKind =
   | "file";
 
 function resolveRadioContext(context?: RadioStatusContext): RadioContextKind {
-  const identifier = context?.identifier?.toLowerCase();
-  if (identifier === "gps") return "gps";
-  if (identifier === "filter_sharpness") return "filter_sharpness";
-  if (identifier === "static_net_params") return "static_net_params";
-  if (identifier === "oscillator") return "oscillator";
-
   const source = context?.source?.toLowerCase();
   if (source === "gps") return "gps";
   if (source === "interlock") return "interlock";
@@ -1399,6 +1393,12 @@ function resolveRadioContext(context?: RadioStatusContext): RadioContextKind {
   if (source === "atu") return "atu";
   if (source === "waveform") return "waveform";
   if (source === "file") return "file";
+
+  const identifier = context?.identifier?.toLowerCase();
+  if (identifier === "gps") return "gps";
+  if (identifier === "filter_sharpness") return "filter_sharpness";
+  if (identifier === "static_net_params") return "static_net_params";
+  if (identifier === "oscillator") return "oscillator";
 
   return "radio";
 }

--- a/packages/flexlib/src/flex/state/radio.ts
+++ b/packages/flexlib/src/flex/state/radio.ts
@@ -441,7 +441,7 @@ function applyRadioSourceAttributes(
         partial.fpgaVersion = value;
         break;
       case "gps": {
-        const normalized = value?.trim().toLowerCase();
+        const normalized = value?.toLowerCase();
         if (normalized) {
           partial.gpsInstalled = normalized !== "not present";
           if (normalized === "locked") partial.gpsLock = true;
@@ -1042,7 +1042,6 @@ function parseAmplifierHandles(
   value: string | undefined,
 ): readonly string[] | undefined {
   if (!value) return undefined;
-  if (!value.trim()) return Object.freeze([]) as readonly string[];
   const handles = value
     .split(",")
     .map((handle) => handle.trim())
@@ -1103,7 +1102,7 @@ function parseTuneMode(
   value: string | undefined,
 ): "single_tone" | "two_tone" | undefined {
   if (!value) return undefined;
-  const normalized = value.trim().toLowerCase();
+  const normalized = value.toLowerCase();
   if (normalized === "two_tone") return "two_tone";
   if (normalized === "single_tone") return "single_tone";
   return undefined;
@@ -1157,7 +1156,7 @@ const INTERLOCK_MOX_STATES = new Set<RadioInterlockState>([
 
 function parseScreensaverMode(value: string | undefined): RadioScreensaverMode {
   if (!value) return "none";
-  const normalized = value.trim().toLowerCase();
+  const normalized = value.toLowerCase();
   if (normalized === "model") return "model";
   if (normalized === "name") return "name";
   if (normalized === "callsign") return "callsign";
@@ -1184,8 +1183,7 @@ function parseAtuTuneStatus(
   value: string | undefined,
 ): RadioAtuTuneStatus | undefined {
   if (!value) return undefined;
-  const normalized = value.trim().toUpperCase();
-  if (!normalized) return undefined;
+  const normalized = value.toUpperCase();
   return ATU_TUNE_STATUS_BY_TOKEN[normalized];
 }
 
@@ -1352,7 +1350,7 @@ function applyGpsStatusAttributes(
         partial.gpsGnssPoweredAntenna = isTruthy(value);
         break;
       case "gps": {
-        const normalized = value?.trim().toLowerCase();
+        const normalized = value?.toLowerCase();
         if (normalized) {
           partial.gpsInstalled = normalized !== "not present";
           if (normalized === "locked") partial.gpsLock = true;
@@ -1526,15 +1524,14 @@ function normalizeProfileSelection(
   value: string | undefined,
 ): string | undefined {
   if (value === undefined) return undefined;
-  const trimmed = value.trim();
-  return trimmed.length ? trimmed : undefined;
+  return value.length ? value : undefined;
 }
 
 function parseFilterSharpnessMode(
   token: string | undefined,
 ): RadioFilterSharpnessMode | undefined {
   if (!token) return undefined;
-  const normalized = token.trim().toLowerCase();
+  const normalized = token.toLowerCase();
   if (normalized === "voice") return "voice";
   if (normalized === "cw") return "cw";
   if (normalized === "digital") return "digital";
@@ -1542,28 +1539,26 @@ function parseFilterSharpnessMode(
 }
 
 function parseIpAddress(value: string | undefined): string | undefined {
-  if (value === undefined) return undefined;
-  const normalized = value.trim();
-  if (!normalized) return undefined;
-  if (normalized.includes(":")) {
+  if (!value) return undefined;
+  if (value.includes(":")) {
     // Basic validation for IPv6 literals.
-    return /^[0-9a-fA-F:]+$/.test(normalized) ? normalized : undefined;
+    return /^[0-9a-fA-F:]+$/.test(value) ? value : undefined;
   }
-  const parts = normalized.split(".");
+  const parts = value.split(".");
   if (parts.length !== 4) return undefined;
   for (const part of parts) {
     if (!/^\d+$/.test(part)) return undefined;
     const octet = Number.parseInt(part, 10);
     if (!Number.isFinite(octet) || octet < 0 || octet > 255) return undefined;
   }
-  return normalized;
+  return value;
 }
 
 function parseOscillatorSetting(
   value: string | undefined,
 ): RadioOscillatorSetting | undefined {
   if (!value) return undefined;
-  const normalized = value.trim().toLowerCase();
+  const normalized = value.toLowerCase();
   if (normalized === "auto") return "auto";
   if (normalized === "external") return "external";
   if (normalized === "gpsdo") return "gpsdo";

--- a/packages/flexlib/src/flex/state/slice.ts
+++ b/packages/flexlib/src/flex/state/slice.ts
@@ -470,7 +470,7 @@ export function createSliceSnapshot(
         partial.recordingEnabled = isTruthy(value);
         break;
       case "play": {
-        const normalized = value?.trim().toLowerCase();
+        const normalized = value?.toLowerCase();
         if (!value || normalized === "disabled") {
           partial.playbackAvailable = false;
           partial.playbackEnabled = false;

--- a/packages/flexlib/src/flex/state/spot.ts
+++ b/packages/flexlib/src/flex/state/spot.ts
@@ -62,7 +62,7 @@ export function createSpotSnapshot(
   for (const [key, value] of Object.entries(attributes)) {
     switch (key) {
       case "callsign":
-        partial.callsign = value.replace(/\u007f/g, " ");
+        partial.callsign = value;
         break;
       case "rx_freq": {
         const parsed = parseFloatSafe(value);
@@ -104,7 +104,7 @@ export function createSpotSnapshot(
         break;
       }
       case "comment":
-        partial.comment = value.replace(/\u007f/g, " ");
+        partial.comment = value;
         break;
       case "priority": {
         const parsed = parseInteger(value);

--- a/packages/flexlib/src/flex/state/waveform.ts
+++ b/packages/flexlib/src/flex/state/waveform.ts
@@ -89,11 +89,11 @@ export function parseLegacyWaveformList(
     const trimmed = rawEntry.trim();
     if (!trimmed) continue;
 
-    const separatorIndex = trimmed.indexOf("\u007f");
+    const separatorIndex = trimmed.indexOf("  ");
     if (separatorIndex === -1) continue;
 
     const name = normalizeWaveformToken(trimmed.slice(0, separatorIndex));
-    const version = normalizeWaveformToken(trimmed.slice(separatorIndex + 1));
+    const version = normalizeWaveformToken(trimmed.slice(separatorIndex + 2));
     if (!name) continue;
 
     entries.push({
@@ -108,5 +108,5 @@ export function parseLegacyWaveformList(
 }
 
 function normalizeWaveformToken(value: string | undefined): string {
-  return value?.replace(/\u007f/g, " ").trim() ?? "";
+  return value?.trim() ?? "";
 }

--- a/packages/flexlib/tests/flex/memory.spec.ts
+++ b/packages/flexlib/tests/flex/memory.spec.ts
@@ -9,9 +9,9 @@ import { createConnectedRadio } from "../helpers.js";
 describe("MemorySnapshot parser", () => {
   it("parses all wire attributes on first creation", () => {
     const attributes: Record<string, string> = {
-      owner: "Dave\u007fHayes",
+      owner: "KF0SMY",
       group: "HF",
-      name: "40m\u007fSSB",
+      name: "40m SSB",
       freq: "7.250000",
       mode: "USB",
       step: "100",
@@ -32,7 +32,7 @@ describe("MemorySnapshot parser", () => {
     const { snapshot, diff } = createMemorySnapshot("0", attributes);
 
     expect(snapshot.id).toBe("0");
-    expect(snapshot.owner).toBe("Dave Hayes");
+    expect(snapshot.owner).toBe("KF0SMY");
     expect(snapshot.group).toBe("HF");
     expect(snapshot.name).toBe("40m SSB");
     expect(snapshot.frequencyMHz).toBeCloseTo(7.25);
@@ -51,7 +51,7 @@ describe("MemorySnapshot parser", () => {
     expect(snapshot.diglOffsetHz).toBe(0);
     expect(snapshot.diguOffsetHz).toBe(0);
     expect(diff.id).toBe("0");
-    expect(snapshot.raw["owner"]).toBe("Dave\u007fHayes");
+    expect(snapshot.raw["owner"]).toBe("KF0SMY");
   });
 
   it("incrementally updates from a previous snapshot", () => {
@@ -74,18 +74,6 @@ describe("MemorySnapshot parser", () => {
     expect(diff.mode).toBe("LSB");
     expect(diff.stepHz).toBeUndefined();
     expect(diff.id).toBeUndefined();
-  });
-
-  it("decodes \\u007f as space in owner, group, and name", () => {
-    const { snapshot } = createMemorySnapshot("0", {
-      owner: "John\u007fDoe",
-      group: "40\u007fm",
-      name: "My\u007fFreq",
-    });
-
-    expect(snapshot.owner).toBe("John Doe");
-    expect(snapshot.group).toBe("40 m");
-    expect(snapshot.name).toBe("My Freq");
   });
 
   it("logs unknown attributes", () => {

--- a/packages/flexlib/tests/flex/protocol.spec.ts
+++ b/packages/flexlib/tests/flex/protocol.spec.ts
@@ -27,16 +27,17 @@ describe("parseFlexMessage", () => {
     expect(message.message).toBe("slice created");
   });
 
-  it("parses notices and normalizes severity", () => {
+  it("parses notices and extracts severity from message code", () => {
     const message = parseFlexMessage(
-      "M|warn|High SWR|ant=ANT1,vswr=3.2",
+      "M31000003|Interlock is preventing transmission",
       Date.now(),
     );
     expect(message).toBeDefined();
     if (!message || message.kind !== "notice")
       throw new Error("expected notice");
+    expect(message.code).toBe(0x31000003);
     expect(message.severity).toBe("warning");
-    expect(message.metadata?.vswr).toBe("3.2");
+    expect(message.text).toBe("Interlock is preventing transmission");
   });
 
   it("parses gps status with hash-delimited attributes", () => {

--- a/packages/flexlib/tests/flex/state.spec.ts
+++ b/packages/flexlib/tests/flex/state.spec.ts
@@ -496,7 +496,9 @@ describe("createRadioStateStore", () => {
     const store = createRadioStateStore();
 
     const changes = store.apply(
-      makeStatus("S1|waveform installed_list=NAVTEX\u007f1.0,RapidM\u007f2.1"),
+      makeStatus(
+        "S1|waveform installed_list=NAVTEX\u007f\u007f1.0,RapidM\u007f\u007f2.1",
+      ),
     );
 
     expect(store.getWaveforms()).toHaveLength(2);
@@ -511,7 +513,7 @@ describe("createRadioStateStore", () => {
     store.apply(makeStatus("S2|waveform container name=FT8 version=0.9"));
     expect(store.getWaveforms()).toHaveLength(3);
 
-    store.apply(makeStatus("S3|waveform installed_list=RapidM\u007f2.1"));
+    store.apply(makeStatus("S3|waveform installed_list=RapidM\u007f\u007f2.1"));
     expect(
       store.getWaveforms().map((waveform) => waveform.displayName),
     ).toEqual(["RapidM 2.1", "FT8 0.9"]);
@@ -669,7 +671,7 @@ describe("createRadioStateStore", () => {
 
     const { snapshot } = createGuiClientSnapshot(
       "0x29DD2CDC",
-      { station: "Home\u007fOffice" },
+      { station: "Home Office" },
       previous,
     );
 
@@ -678,7 +680,7 @@ describe("createRadioStateStore", () => {
     expect(snapshot.station).toBe("Home Office");
     expect(snapshot.raw["client_id"]).toBe("ABCD1234");
     expect(snapshot.raw["program"]).toBe("SmartSDR");
-    expect(snapshot.raw["station"]).toBe("Home\u007fOffice");
+    expect(snapshot.raw["station"]).toBe("Home Office");
   });
 
   it("tracks log available levels and modules", () => {

--- a/packages/flexlib/tests/flex/waveform.spec.ts
+++ b/packages/flexlib/tests/flex/waveform.spec.ts
@@ -6,7 +6,7 @@ describe("waveform controller", () => {
   it("tracks waveform state and sends uninstall/restart commands", async () => {
     const { radio, connection } = await createConnectedRadio();
 
-    connection.emitStatus("S1|waveform installed_list=NAVTEX\u007f1.0");
+    connection.emitStatus("S1|waveform installed_list=NAVTEX\u007f\u007f1.0");
     connection.emitStatus("S2|waveform container name=FT8 version=0.9");
 
     const legacy = radio


### PR DESCRIPTION
Better handling of status message parsing. Namely, normalization of values containing `\u007f` were moved into the attribute parsing so it happens globally instead of in a dozen different state parsers, same with whitespace trimming. Also, `M` messages from the radio now correctly get a parsed severity. Plus a few more subscriptions during the connection handshake.