### PR TITLE
Notification Improvements

### DIFF
--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,112 @@
+import type { JSX, ValidComponent } from "solid-js"
+import { splitProps } from "solid-js"
+
+import * as AlertDialogPrimitive from "@kobalte/core/alert-dialog"
+import type { PolymorphicProps } from "@kobalte/core/polymorphic"
+
+import { cn } from "~/lib/utils"
+
+const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+type AlertDialogOverlayProps<T extends ValidComponent = "div"> =
+  AlertDialogPrimitive.AlertDialogOverlayProps<T> & {
+    class?: string | undefined
+  }
+
+const AlertDialogOverlay = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, AlertDialogOverlayProps<T>>
+) => {
+  const [local, others] = splitProps(props as AlertDialogOverlayProps, ["class"])
+  return (
+    <AlertDialogPrimitive.Overlay
+      class={cn(
+        "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[expanded]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0",
+        local.class
+      )}
+      {...others}
+    />
+  )
+}
+
+type AlertDialogContentProps<T extends ValidComponent = "div"> =
+  AlertDialogPrimitive.AlertDialogContentProps<T> & {
+    class?: string | undefined
+    children?: JSX.Element
+  }
+
+const AlertDialogContent = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, AlertDialogContentProps<T>>
+) => {
+  const [local, others] = splitProps(props as AlertDialogContentProps, ["class", "children"])
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        class={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[expanded]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] sm:rounded-lg md:w-full",
+          local.class
+        )}
+        {...others}
+      >
+        {local.children}
+        <AlertDialogPrimitive.CloseButton class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[expanded]:bg-accent data-[expanded]:text-muted-foreground">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="size-4"
+          >
+            <path d="M18 6l-12 12" />
+            <path d="M6 6l12 12" />
+          </svg>
+          <span class="sr-only">Close</span>
+        </AlertDialogPrimitive.CloseButton>
+      </AlertDialogPrimitive.Content>
+    </AlertDialogPortal>
+  )
+}
+
+type AlertDialogTitleProps<T extends ValidComponent = "h2"> =
+  AlertDialogPrimitive.AlertDialogTitleProps<T> & {
+    class?: string | undefined
+  }
+
+const AlertDialogTitle = <T extends ValidComponent = "h2">(
+  props: PolymorphicProps<T, AlertDialogTitleProps<T>>
+) => {
+  const [local, others] = splitProps(props as AlertDialogTitleProps, ["class"])
+  return <AlertDialogPrimitive.Title class={cn("text-lg font-semibold", local.class)} {...others} />
+}
+
+type AlertDialogDescriptionProps<T extends ValidComponent = "p"> =
+  AlertDialogPrimitive.AlertDialogDescriptionProps<T> & {
+    class?: string | undefined
+  }
+
+const AlertDialogDescription = <T extends ValidComponent = "p">(
+  props: PolymorphicProps<T, AlertDialogDescriptionProps<T>>
+) => {
+  const [local, others] = splitProps(props as AlertDialogDescriptionProps, ["class"])
+  return (
+    <AlertDialogPrimitive.Description
+      class={cn("text-sm text-muted-foreground", local.class)}
+      {...others}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogDescription
+}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -145,8 +145,8 @@ function showToast(props: {
   description?: JSX.Element;
   variant?: ToastVariant;
   duration?: number;
-}) {
-  ToastPrimitive.toaster.show((data) => (
+}): number {
+  return ToastPrimitive.toaster.show((data) => (
     <Toast
       toastId={data.toastId}
       variant={props.variant}

--- a/apps/web/src/context/flexradio.tsx
+++ b/apps/web/src/context/flexradio.tsx
@@ -55,6 +55,13 @@ import { Timeline } from "~/components/ui/timeline";
 import { InfoItem } from "~/components/settings/common";
 import { ReactiveMap } from "@solid-primitives/map";
 import { FlexRadioDescriptor } from "@repo/flexlib";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import * as ToastPrimitive from "@kobalte/core/toast";
 
 export enum ConnectionState {
   disconnected,
@@ -204,8 +211,12 @@ export const FlexRadioProvider: ParentComponent = (props) => {
   const { preferences, setPreferences } = usePreferences();
   const { peerConnection, rtcState, signalingWsState } = useRtc();
   const [activeRadio, setActiveRadio] = createSignal<Radio | null>(null);
+  const [showAlert, setShowAlert] = createSignal(false);
+  const [alertMessage, setAlertMessage] = createSignal("");
 
   const spots = new ReactiveMap<string, SpotState>();
+
+  createEffect(() => setShowAlert(Boolean(alertMessage())));
 
   let radioSubscriptions: Subscription[] = [];
 
@@ -413,22 +424,52 @@ export const FlexRadioProvider: ParentComponent = (props) => {
     setState("selectedPanadapter", firstOwnPan ?? null);
   });
 
-  const handleNoticePayload = (payload: string) => {
-    const [, description] = payload.split("|");
-    if (description) {
-      showToast({ description, variant: "info" });
-    }
-  };
+  const previousToasts: Record<string, number> = {};
 
   const handleFlexMessage = (message: FlexWireMessage) => {
     switch (message.kind) {
       case "notice":
-        handleNoticePayload(message.raw);
+        // this keeps us from spamming duplicate messages
+        if (message.text in previousToasts) {
+          ToastPrimitive.toaster.dismiss(previousToasts[message.text]);
+        }
+        switch (message.severity) {
+          case "info":
+            console.info(message.text);
+            previousToasts[message.text] = showToast({
+              description: message.text,
+              variant: message.severity,
+            });
+            break;
+          case "warning":
+            console.warn(message.text);
+            previousToasts[message.text] = showToast({
+              description: message.text,
+              variant: message.severity,
+            });
+            break;
+          case "error": {
+            console.error(message.text);
+            previousToasts[message.text] = showToast({
+              description: message.text,
+              variant: message.severity,
+            });
+            break;
+          }
+          case "fatal": {
+            console.error(message.text);
+            setAlertMessage(message.text);
+            break;
+          }
+          default:
+            console.log(message.text);
+            previousToasts[message.text] = showToast({
+              description: message.text,
+            });
+        }
         break;
       case "reply":
         switch (message.level) {
-          case "success":
-            break;
           case "info":
             console.info("Command reply", message.raw);
             break;
@@ -669,6 +710,17 @@ export const FlexRadioProvider: ParentComponent = (props) => {
       >
         {props.children}
       </Show>
+      <AlertDialog
+        open={showAlert()}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setAlertMessage("");
+        }}
+      >
+        <AlertDialogContent class="border-error-foreground">
+          <AlertDialogTitle>Fatal Error</AlertDialogTitle>
+          <AlertDialogDescription>{alertMessage()}</AlertDialogDescription>
+        </AlertDialogContent>
+      </AlertDialog>
     </FlexRadioContext.Provider>
   );
 };


### PR DESCRIPTION
## Notification Improvements

Notifications are correctly color-coded based on severity:

<img width="406" height="207" alt="image" src="https://github.com/user-attachments/assets/346aeb03-8123-4762-a933-585421ed4a09" />

Notifications with Fatal severity are shown as a modal alert dialog:

<img width="545" height="145" alt="image" src="https://github.com/user-attachments/assets/1d544bf4-e645-436d-a898-4ef68779a11c" />

Notifications are deduplicated so we don't fill the notification area up with duplicate message spam:

<img width="403" height="84" alt="image" src="https://github.com/user-attachments/assets/dcf6353f-eb39-4426-abfd-bd4e8f76e01d" />