### PR TITLE
Add APD sampler settings

### DIFF
--- a/apps/web/src/components/settings/radio-settings.tsx
+++ b/apps/web/src/components/settings/radio-settings.tsx
@@ -28,6 +28,7 @@ import {
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import useFlexRadio, { FilterPresetState } from "~/context/flexradio";
 import type {
+  ApdSamplerPort,
   FilterPresetEntry,
   FlexCommandRejectedError,
   Radio,
@@ -550,6 +551,23 @@ function RadioSettingsInner(props: { radio: Radio }) {
             value={`v${state.status.featureLicense.highestMajorVersion}.x`}
           />
         </CardContent>
+        <CardFooter class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 items-stretch">
+          <Button
+            onClick={() =>
+              showToastPromise(
+                props.radio.featureLicense().refreshLicenseState(),
+                {
+                  loading: "Refreshing license",
+                  success: () => "License refreshed successfully",
+                  error: (e: FlexCommandRejectedError) =>
+                    e.codeDescription ?? "Error refreshing license",
+                },
+              )
+            }
+          >
+            Refresh
+          </Button>
+        </CardFooter>
       </Card>
       <Card class="bg-transparent">
         <CardHeader>
@@ -1484,6 +1502,122 @@ function RadioSettingsInner(props: { radio: Radio }) {
           </Button>
         </CardFooter>
       </Card>
+      <Show when={state.status.apd?.configurable}>
+        <Card class="bg-transparent">
+          <CardHeader>
+            <CardTitle>APD</CardTitle>
+          </CardHeader>
+          <CardContent class="select-none flex flex-col gap-4">
+            <Select
+              class="flex flex-col gap-2 select-none"
+              value={state.status.apd.selectedSamplerPortAnt1}
+              onChange={(value: ApdSamplerPort) =>
+                props.radio.apd().setSamplerPort("ANT1", value)
+              }
+              options={Array.from(state.status.apd.availableSamplerPortsAnt1)}
+              itemComponent={(props) => {
+                return (
+                  <SelectItem item={props.item} class="uppercase">
+                    {props.item.rawValue.toString()}
+                  </SelectItem>
+                );
+              }}
+            >
+              <SelectLabel>ANT1 Sampler Port</SelectLabel>
+              <SelectTrigger class="uppercase">
+                <SelectValue<string>>
+                  {(state) => state.selectedOption()}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent />
+            </Select>
+            <Select
+              class="flex flex-col gap-2 select-none"
+              value={state.status.apd.selectedSamplerPortAnt2}
+              onChange={(value: ApdSamplerPort) =>
+                props.radio.apd().setSamplerPort("ANT2", value)
+              }
+              options={Array.from(state.status.apd.availableSamplerPortsAnt2)}
+              itemComponent={(props) => {
+                return (
+                  <SelectItem item={props.item} class="uppercase">
+                    {props.item.rawValue.toString()}
+                  </SelectItem>
+                );
+              }}
+            >
+              <SelectLabel>ANT2 Sampler Port</SelectLabel>
+              <SelectTrigger class="uppercase">
+                <SelectValue<ApdSamplerPort>>
+                  {(state) => state.selectedOption()}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent />
+            </Select>
+            <Select
+              class="flex flex-col gap-2 select-none"
+              value={state.status.apd.selectedSamplerPortXvta}
+              onChange={(value: ApdSamplerPort) =>
+                props.radio.apd().setSamplerPort("XVTA", value)
+              }
+              options={Array.from(state.status.apd.availableSamplerPortsXvta)}
+              itemComponent={(props) => {
+                return (
+                  <SelectItem item={props.item} class="uppercase">
+                    {props.item.rawValue.toString()}
+                  </SelectItem>
+                );
+              }}
+            >
+              <SelectLabel>XVTA Sampler Port</SelectLabel>
+              <SelectTrigger class="uppercase">
+                <SelectValue<ApdSamplerPort>>
+                  {(state) => state.selectedOption()}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent />
+            </Select>
+            <Show when={state.status.radio.rxAntennaList.includes("XVTB")}>
+              <Select
+                class="flex flex-col gap-2 select-none"
+                value={state.status.apd.selectedSamplerPortXvtb}
+                onChange={(value: ApdSamplerPort) =>
+                  props.radio.apd().setSamplerPort("XVTB", value)
+                }
+                options={Array.from(state.status.apd.availableSamplerPortsXvtb)}
+                itemComponent={(props) => {
+                  return (
+                    <SelectItem item={props.item} class="uppercase">
+                      {props.item.rawValue.toString()}
+                    </SelectItem>
+                  );
+                }}
+              >
+                <SelectLabel>XVTB Sampler Port</SelectLabel>
+                <SelectTrigger class="uppercase">
+                  <SelectValue<ApdSamplerPort>>
+                    {(state) => state.selectedOption()}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent />
+              </Select>
+            </Show>
+          </CardContent>
+          <CardFooter class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 items-stretch">
+            <Button
+              onClick={() =>
+                showToastPromise(props.radio.apd().equalizerReset(), {
+                  loading: "Resetting APD equalizer",
+                  success: () => "APD equalizer reset successfully",
+                  error: () => "Error resetting APD equalizer",
+                })
+              }
+            >
+              Reset Equalizer
+            </Button>
+          </CardFooter>
+        </Card>
+      </Show>
     </div>
   );
 }

--- a/packages/flexlib/src/flex/feature-license.ts
+++ b/packages/flexlib/src/flex/feature-license.ts
@@ -7,11 +7,21 @@ import { FlexStateUnavailableError } from "./errors.js";
 
 export type { FeatureLicenseFeature } from "./state/feature-license.js";
 
-export interface FeatureLicenseController
-  extends Readonly<Omit<FeatureLicenseSnapshot, "raw">> {
+export interface FeatureLicenseController extends Readonly<
+  Omit<FeatureLicenseSnapshot, "raw">
+> {
   snapshot(): FeatureLicenseSnapshot;
   getFeature(name: string): FeatureLicenseFeature | undefined;
   listFeatures(): readonly FeatureLicenseFeature[];
+  /** Send `license refresh` to re-fetch the radio's license state from the server. */
+  refreshLicenseState(): Promise<void>;
+  /**
+   * Upload a license key to the radio. `licenseKey` is the content of a
+   * FlexRadio `.lic` file with the `BEGIN/END LICENSE KEY` header lines and
+   * all newlines removed. The file's body is already base64-encoded by
+   * FlexRadio; no additional encoding is required before calling this method.
+   */
+  uploadLicense(licenseKey: string): Promise<void>;
 }
 
 export class FeatureLicenseControllerImpl implements FeatureLicenseController {
@@ -83,5 +93,13 @@ export class FeatureLicenseControllerImpl implements FeatureLicenseController {
 
   listFeatures(): readonly FeatureLicenseFeature[] {
     return Object.values(this.current().features);
+  }
+
+  async refreshLicenseState(): Promise<void> {
+    console.log(await this.radio.command("license refresh"));
+  }
+
+  async uploadLicense(licenseKey: string): Promise<void> {
+    await this.radio.command(`license set=${licenseKey}`);
   }
 }


### PR DESCRIPTION
## APD Settings

The Radio Settings dialog gains a new APD card with sampler port selections and a Reset Equalizer button.

<img width="494" height="469" alt="image" src="https://github.com/user-attachments/assets/8ee9e73c-6081-4d6f-a460-3d78aa946454" />
