### PR TITLE
Server Defaults

### DIFF
--- a/apps/server/cmd/bridge/main.go
+++ b/apps/server/cmd/bridge/main.go
@@ -51,6 +51,7 @@ func main() {
 	// ---- HTTP mux ----
 	mux := http.NewServeMux()
 	mux.Handle("/ws/signal", rtcServer)
+	mux.HandleFunc("/defaults.json", makeDefaultsHandler(cfg.DefaultsFile))
 
 	if cfg.StaticDir != "" {
 		mux.Handle("/", http.FileServer(http.Dir(cfg.StaticDir)))
@@ -108,6 +109,29 @@ func isVersionFlag(v string) bool {
 	}
 
 	return false
+}
+
+func makeDefaultsHandler(path string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if path == "" {
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				http.NotFound(w, r)
+				return
+			}
+
+			http.Error(w, "failed to read defaults file", http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(data)
+	}
 }
 
 func withCOI(next http.Handler) http.Handler {

--- a/apps/server/internal/config/config.go
+++ b/apps/server/internal/config/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	// Diagnostics
 	APILogFile string `mapstructure:"api-log-file"`
 
+	// Server defaults
+	DefaultsFile string `mapstructure:"defaults-file"`
+
 	// Config file path (optional)
 	ConfigFile string `mapstructure:"-"`
 }
@@ -65,6 +68,7 @@ func Load() (Config, error) {
 	}, "Comma-separated STUN URLs")
 	fs.StringSlice("nat-1to1-ips", nil, "Optional public IPs for NAT 1:1 mapping (e.g. 203.0.113.2,2001:db8::2)")
 	fs.String("api-log-file", defaultAPILogPath(), "Path to write raw TCP API messages (set empty to disable)")
+	fs.String("defaults-file", "", "Path to JSON file served as server defaults (optional)")
 	fs.String("config", "", "Path to optional config file")
 
 	// Usage
@@ -137,8 +141,8 @@ Config file:
 	}
 
 	cfg.ConfigFile = v.ConfigFileUsed()
-	log.Printf("[config] http=:%d static=%q ice=%d..%d api-log=%q file=%q\n",
-		cfg.HTTPPort, cfg.StaticDir, cfg.ICEPortStart, cfg.ICEPortEnd, cfg.APILogFile, cfg.ConfigFile)
+	log.Printf("[config] http=:%d static=%q ice=%d..%d api-log=%q defaults=%q file=%q\n",
+		cfg.HTTPPort, cfg.StaticDir, cfg.ICEPortStart, cfg.ICEPortEnd, cfg.APILogFile, cfg.DefaultsFile, cfg.ConfigFile)
 
 	// Sanity checks
 	if cfg.ICEPortEnd < cfg.ICEPortStart {

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -54,7 +54,7 @@ function App() {
   const storageManager = createLocalStorageManager("vite-ui-theme");
 
   return (
-    <PreferencesProvider>
+    <>
       <ColorModeScript
         initialColorMode="dark"
         storageType={storageManager.type}
@@ -63,45 +63,47 @@ function App() {
         initialColorMode="dark"
         storageManager={storageManager}
       >
-        <Show
-          when={window.isSecureContext}
-          fallback={
-            <Callout
-              variant="error"
-              class="absolute top-1/2 left-1/2 -translate-1/2"
-            >
-              <CalloutTitle>HTTPS Required</CalloutTitle>
-              <CalloutContent class="flex flex-col gap-2">
-                SolidSDR requires a secure context (HTTPS) to work.
-                <div class="flex justify-end">
-                  <Button
-                    as="a"
-                    href="https://github.com/daveisadork/solid-sdr/wiki/Secure-Contexts"
-                    target="_blank"
-                  >
-                    <MaterialSymbolsOpenInNew />
-                    View Docs
-                  </Button>
-                </div>
-              </CalloutContent>
-            </Callout>
-          }
-        >
-          <RtcProvider>
-            <FlexRadioProvider>
-              <RuntimeProvider>
-                <ControlsProvider>
-                  <AppInner />
-                  <RtcAudio /> {/* keeps audio elements mounted */}
-                </ControlsProvider>
-              </RuntimeProvider>
-            </FlexRadioProvider>
-          </RtcProvider>
-        </Show>
+        <PreferencesProvider>
+          <Show
+            when={window.isSecureContext}
+            fallback={
+              <Callout
+                variant="error"
+                class="absolute top-1/2 left-1/2 -translate-1/2"
+              >
+                <CalloutTitle>HTTPS Required</CalloutTitle>
+                <CalloutContent class="flex flex-col gap-2">
+                  SolidSDR requires a secure context (HTTPS) to work.
+                  <div class="flex justify-end">
+                    <Button
+                      as="a"
+                      href="https://github.com/daveisadork/solid-sdr/wiki/Secure-Contexts"
+                      target="_blank"
+                    >
+                      <MaterialSymbolsOpenInNew />
+                      View Docs
+                    </Button>
+                  </div>
+                </CalloutContent>
+              </Callout>
+            }
+          >
+            <RtcProvider>
+              <FlexRadioProvider>
+                <RuntimeProvider>
+                  <ControlsProvider>
+                    <AppInner />
+                    <RtcAudio /> {/* keeps audio elements mounted */}
+                  </ControlsProvider>
+                </RuntimeProvider>
+              </FlexRadioProvider>
+            </RtcProvider>
+          </Show>
+          <ReleaseNotification />
+        </PreferencesProvider>
         <Toaster />
       </ColorModeProvider>
-      <ReleaseNotification />
-    </PreferencesProvider>
+    </>
   );
 }
 

--- a/apps/web/src/context/preferences.tsx
+++ b/apps/web/src/context/preferences.tsx
@@ -5,8 +5,17 @@ import {
   type ParentComponent,
   useContext,
   createEffect,
+  createResource,
+  Show,
+  Suspense,
 } from "solid-js";
-import { createStore, reconcile, SetStoreFunction } from "solid-js/store";
+import {
+  createStore,
+  reconcile,
+  SetStoreFunction,
+  unwrap,
+} from "solid-js/store";
+import { showToast } from "~/components/ui/toast";
 import { DaxChannelMode } from "~/lib/dax-audio-sink/types";
 import { MidiMapping } from "~/lib/midi";
 
@@ -377,7 +386,7 @@ const getDefaults = (): Preferences => ({
   },
 });
 
-const deepMerge = <T extends object>(target: T, source: T): T => {
+const deepMerge = <T extends object>(target: T, source: Partial<T>): T => {
   for (const [key, value] of Object.entries(source)) {
     const targetValue = target[key];
     if (targetValue === value) continue;
@@ -393,17 +402,17 @@ const deepMerge = <T extends object>(target: T, source: T): T => {
   return target;
 };
 
-export const PreferencesProvider: ParentComponent = (props) => {
-  const [store, setStore] = createStore(getDefaults());
+export const PreferencesProviderInner: ParentComponent<{
+  getDefaults: () => Preferences;
+}> = (props) => {
+  const [store, setStore] = createStore(props.getDefaults());
   const [preferences, setPreferences] = makePersisted([store, setStore], {
     name: "preferences",
   });
 
   // populate any missing defaults, and clean up any deprecated/removed prefs
   setPreferences(
-    reconcile(
-      deepMerge(getDefaults(), JSON.parse(JSON.stringify(preferences))),
-    ),
+    reconcile(deepMerge(props.getDefaults(), unwrap(preferences))),
   );
 
   createEffect(() => {
@@ -426,6 +435,56 @@ export const PreferencesProvider: ParentComponent = (props) => {
     <PreferencesContext.Provider value={{ preferences, setPreferences }}>
       {props.children}
     </PreferencesContext.Provider>
+  );
+};
+
+export const PreferencesProvider: ParentComponent = (props) => {
+  const [serverDefaults] = createResource<Partial<Preferences>>(async () => {
+    try {
+      const response = await fetch("/defaults.json");
+      if (!response.ok) throw new Error(response.statusText);
+      const serverDefaults = await response.json();
+      const defaults = getDefaults();
+      for (const key in serverDefaults) {
+        if (!(key in defaults)) {
+          console.warn("Unknown key in serverDefaults:", key);
+        }
+      }
+      if ("guiClientId" in serverDefaults) {
+        console.warn(
+          "serverDefaults contains guiClientId, which is not recommended!",
+        );
+      }
+      return serverDefaults;
+    } catch (err) {
+      console.error(err);
+      showToast({
+        variant: "error",
+        title: "Failed to load server defaults",
+        description: String(err),
+      });
+      return {};
+    }
+  });
+
+  return (
+    <Suspense
+      fallback={
+        <div class="absolute top-1/2 left-1/2 -translate-1/2 border rounded-lg p-4">
+          Loading...
+        </div>
+      }
+    >
+      <Show when={serverDefaults()}>
+        {(serverDefaults) => (
+          <PreferencesProviderInner
+            getDefaults={() => deepMerge(getDefaults(), serverDefaults())}
+          >
+            {props.children}
+          </PreferencesProviderInner>
+        )}
+      </Show>
+    </Suspense>
   );
 };
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
         ws: true,
         rewriteWsOrigin: true,
       },
-      "/rtc": { target: "http://localhost:8080" },
+      "/defaults.json": { target: "http://localhost:8080" },
     },
     headers: {
       // cross-origin isolation for SAB in dev

--- a/solid-sdr-server.example.yaml
+++ b/solid-sdr-server.example.yaml
@@ -33,3 +33,8 @@ stun:
 
 # Path to write raw API message log (default: messages.txt — set empty to disable)
 # api-log-file: messages.txt
+
+# Path to a JSON file of partial preferences to serve as server-defined defaults.
+# Clients merge these into their hardcoded defaults before applying saved preferences.
+# If unset, /defaults.json returns {}. If set but the file is missing, clients receive a 404.
+# defaults-file: /path/to/defaults.json


### PR DESCRIPTION
Closes #15 

Adds a new server config for specifying a file that contains server defaults, and can be used to set default App Settings for all clients:

```
--defaults-file string   Path to JSON file served as server defaults (optional)
```

```yaml
# Path to a JSON file of partial preferences to serve as server-defined defaults.
# Clients merge these into their hardcoded defaults before applying saved preferences.
# If unset, /defaults.json returns {}. If set but the file is missing, clients receive a 404.
defaults-file: /path/to/defaults.json
```

A suitable file can be created using the Export button in the App Settings dialog. It's a good idea to remove anything from the file that isn't being explicitly modified, but `guiClientId` especially should be removed. If the server defaults file contains `guiClientId` or any unknown keys, warnings will be logged in the browser console:

```
Unknown key in serverDefaults: fictionalKey
serverDefaults contains guiClientId, which is not recommended!
```

If a server defaults file is specified, and anything goes wrong trying to load it, (file is missing, contains invalid JSON, etc), users will see an error message on page load, but operation will proceed with standard defaults:

<img width="418" height="113" alt="image" src="https://github.com/user-attachments/assets/885c2794-638a-478a-b572-41589b62a3aa" />
