### PR TITLE
Many misc fixes

### DIFF
--- a/apps/web/src/context/audio.tsx
+++ b/apps/web/src/context/audio.tsx
@@ -221,9 +221,7 @@ export const AudioProvider: ParentComponent = (props) => {
       );
       if (!activeStream) return;
 
-      const sink = new DaxAudioSink({
-        channelMode: preferences.dax.rx[daxChannel]?.channelMode ?? "both",
-      });
+      const sink = new DaxAudioSink();
       const controller = radio()?.audioStream(activeStream.id);
       sink.init().catch(console.error);
       const subscription = controller?.on("data", (event) => sink.play(event));

--- a/apps/web/src/lib/dax-audio-sink/dax-audio-sink.ts
+++ b/apps/web/src/lib/dax-audio-sink/dax-audio-sink.ts
@@ -29,6 +29,7 @@ export class DaxAudioSink {
   private workletNode?: AudioWorkletNode;
   private worker?: Worker;
   private resumePending = false;
+  private closed = false;
 
   private bufferMs: number;
   private channelMode: DaxChannelMode;
@@ -56,7 +57,9 @@ export class DaxAudioSink {
   }
 
   async init(): Promise<void> {
+    if (this.closed) return;
     await this.ctx.audioWorklet.addModule(sabWorkletURL);
+    if (this.closed) return;
     const node = new AudioWorkletNode(this.ctx, "dax-sab-sink", {
       numberOfInputs: 0,
       numberOfOutputs: 1,
@@ -160,13 +163,14 @@ export class DaxAudioSink {
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     try {
       this.worker?.terminate();
       this.worker = undefined;
       this.workletNode?.disconnect();
       this.audio.srcObject = null;
     } finally {
-      await this.ctx.close();
+      if (this.ctx.state !== "closed") await this.ctx.close();
     }
   }
 

--- a/apps/web/src/lib/dax-audio-tx.ts
+++ b/apps/web/src/lib/dax-audio-tx.ts
@@ -68,6 +68,7 @@ export class DaxAudioTx {
   private readonly int16Buf = new Int16Array(DAX_PACKET_SAMPLES);
   private worklet?: AudioWorkletNode;
   private started = false;
+  private closed = false;
   private channelMode: DaxChannelMode;
 
   constructor(
@@ -89,7 +90,9 @@ export class DaxAudioTx {
 
   async start(): Promise<void> {
     if (!this.started) {
+      if (this.closed) return;
       await this.context.audioWorklet.addModule(daxAudioTxProcessorURL);
+      if (this.closed) return;
       const worklet = new AudioWorkletNode(this.context, "dax-audio-tx", {
         numberOfInputs: 1,
         numberOfOutputs: 1,
@@ -134,18 +137,20 @@ export class DaxAudioTx {
       this.started = true;
     }
 
+    if (this.closed) return;
     if (this.context.state !== "running") {
       await this.context.resume();
     }
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     console.log("Closing dax tx");
     this.worklet?.port.close();
     this.worklet?.disconnect();
     this.mute.disconnect();
     this.source.disconnect();
-    await this.context.close();
+    if (this.context.state !== "closed") await this.context.close();
   }
 }
 

--- a/packages/flexlib/src/flex/audio-stream.ts
+++ b/packages/flexlib/src/flex/audio-stream.ts
@@ -1,4 +1,5 @@
 import { TypedEventEmitter, type Subscription } from "../util/events.js";
+import { clampInteger } from "./controller-helpers.js";
 import { FlexStateUnavailableError } from "./errors.js";
 import type {
   AudioStreamSnapshot,
@@ -71,6 +72,17 @@ export interface RemoteAudioTxStreamController extends AudioStreamTxController {
    * VITA-49 packet framing, sequencing, and stream ID.
    */
   sendOpus(frame: Uint8Array): void;
+}
+
+/** DAX RX stream controller with per-channel RX gain. */
+export interface DaxRxAudioStreamController extends AudioStreamController {
+  /**
+   * Set the RX gain (0..100) for this DAX RX channel.
+   *
+   * Requires the stream to be bound to a slice. Throws
+   * {@link FlexStateUnavailableError} if no slice is currently bound.
+   */
+  setRxGain(gain: number): Promise<void>;
 }
 
 export class AudioStreamControllerImpl implements AudioStreamController {
@@ -262,6 +274,34 @@ export class DaxTxAudioStreamControllerImpl
 {
   async requestTx(tx: boolean): Promise<void> {
     await this.radio.command(`stream set ${this.id} tx=${tx ? 1 : 0}`);
+  }
+}
+
+/** DAX RX audio stream with per-channel RX gain. */
+export class DaxRxAudioStreamControllerImpl
+  extends AudioStreamControllerImpl
+  implements DaxRxAudioStreamController
+{
+  async setRxGain(gain: number): Promise<void> {
+    const sliceLetter = this.slice;
+    if (sliceLetter === undefined) {
+      throw new FlexStateUnavailableError(
+        `DAX RX stream ${this.id} has no slice bound; cannot set gain`,
+      );
+    }
+    const slice = this.radio
+      .getStore()
+      .getSlices()
+      .find((s) => s.indexLetter === sliceLetter);
+    if (!slice) {
+      throw new FlexStateUnavailableError(
+        `DAX RX stream ${this.id} bound to slice ${sliceLetter} but slice is not in store`,
+      );
+    }
+    const clamped = clampInteger(gain, 0, 100, "DAX RX gain");
+    await this.radio.command(
+      `audio stream ${this.id} slice ${slice.id} gain ${clamped}`,
+    );
   }
 }
 

--- a/packages/flexlib/src/flex/cwx.ts
+++ b/packages/flexlib/src/flex/cwx.ts
@@ -132,7 +132,7 @@ export class CwxControllerImpl implements CwxController {
   }
 
   async send(text: string): Promise<void> {
-    await this.radio.command(`cwx send "${text}"`);
+    await this.radio.command(`cwx send "${text.replaceAll(" ", "\x7f")}"`);
   }
 
   async erase(count: number): Promise<void> {

--- a/packages/flexlib/src/flex/feature-license.ts
+++ b/packages/flexlib/src/flex/feature-license.ts
@@ -96,7 +96,7 @@ export class FeatureLicenseControllerImpl implements FeatureLicenseController {
   }
 
   async refreshLicenseState(): Promise<void> {
-    console.log(await this.radio.command("license refresh"));
+    await this.radio.command("license refresh");
   }
 
   async uploadLicense(licenseKey: string): Promise<void> {

--- a/packages/flexlib/src/flex/radio-core.ts
+++ b/packages/flexlib/src/flex/radio-core.ts
@@ -1287,6 +1287,11 @@ class RadioImpl {
     this.emitDisconnected(undefined);
   }
 
+  /** Reboot the radio's firmware. The connection will drop shortly after. */
+  async rebootRadio(): Promise<void> {
+    await this.command("radio reboot");
+  }
+
   // -----------------------------------------------------------------------
   // Commands
   // -----------------------------------------------------------------------

--- a/packages/flexlib/src/flex/radio-core.ts
+++ b/packages/flexlib/src/flex/radio-core.ts
@@ -1292,6 +1292,16 @@ class RadioImpl {
     await this.command("radio reboot");
   }
 
+  /** Install the GPS subsystem on a GPS-equipped radio. */
+  async gpsInstall(): Promise<void> {
+    await this.command("radio gps install");
+  }
+
+  /** Uninstall the GPS subsystem on a GPS-equipped radio. */
+  async gpsUninstall(): Promise<void> {
+    await this.command("radio gps uninstall");
+  }
+
   // -----------------------------------------------------------------------
   // Commands
   // -----------------------------------------------------------------------

--- a/packages/flexlib/src/flex/radio-core.ts
+++ b/packages/flexlib/src/flex/radio-core.ts
@@ -74,11 +74,13 @@ import {
 import { type MeterController, MeterControllerImpl } from "./meter.js";
 import {
   type AudioStreamController,
+  type DaxRxAudioStreamController,
   type DaxTxAudioStreamController,
   type AudioStreamTxController,
   type RemoteAudioTxStreamController,
   AudioStreamControllerImpl,
   AudioStreamTxControllerImpl,
+  DaxRxAudioStreamControllerImpl,
   DaxTxAudioStreamControllerImpl,
   RemoteAudioTxStreamControllerImpl,
 } from "./audio-stream.js";
@@ -1073,11 +1075,11 @@ class RadioImpl {
 
   async createDaxRxAudioStream(options: {
     daxChannel: number;
-  }): Promise<AudioStreamController> {
+  }): Promise<DaxRxAudioStreamController> {
     const channel = toInteger(options.daxChannel, "DAX RX channel");
     return this.createAudioStreamController(
       `stream create type=dax_rx dax_channel=${channel}`,
-      AudioStreamControllerImpl,
+      DaxRxAudioStreamControllerImpl,
     );
   }
 

--- a/packages/flexlib/src/flex/state/dvk.ts
+++ b/packages/flexlib/src/flex/state/dvk.ts
@@ -128,6 +128,11 @@ export function createDvkSnapshot(
           break;
       }
     }
+
+    if ("enabled" in attributes && partial.enabled === false) {
+      partial.status = "disabled";
+      partial.statusRecordingId = undefined;
+    }
   }
 
   const snapshot = Object.freeze({

--- a/packages/flexlib/src/flex/state/feature-license.ts
+++ b/packages/flexlib/src/flex/state/feature-license.ts
@@ -150,11 +150,12 @@ function applySubscriptionAttributes(
     [name]: subscription,
   });
 
+  const active = expiration !== undefined && expiration.getTime() > Date.now();
   if (name === "smartsdr+") {
-    partial.smartSdrPlusActive = true;
+    partial.smartSdrPlusActive = active;
     partial.smartSdrPlusExpiration = expiration;
   } else if (name === "smartsdr+_early_access") {
-    partial.smartSdrPlusEarlyAccessActive = true;
+    partial.smartSdrPlusEarlyAccessActive = active;
     partial.smartSdrPlusEarlyAccessExpiration = expiration;
   }
 }

--- a/packages/flexlib/src/flex/xvtr.ts
+++ b/packages/flexlib/src/flex/xvtr.ts
@@ -145,7 +145,25 @@ export class XvtrControllerImpl implements XvtrController {
   }
 
   async setMaxPowerDbm(power: number): Promise<void> {
-    const clamped = clampNumber(ensureFinite(power, "Max power"), -10);
+    const finite = ensureFinite(power, "Max power");
+    const ifFreq = this.current().ifFreqMHz;
+    const model = this.radio.getStore().getRadio()?.model;
+    let max: number;
+    if (ifFreq < 80.0) {
+      if (
+        model === "FLEX-6400" ||
+        model === "FLEX-6400M" ||
+        model === "FLEX-6600" ||
+        model === "FLEX-6600M"
+      ) {
+        max = 10.0;
+      } else {
+        max = 15.0;
+      }
+    } else {
+      max = 8.0;
+    }
+    const clamped = clampNumber(finite, -10, max);
     const value = clamped.toFixed(2);
     await this.sendSet({ max_power: value });
   }

--- a/packages/flexlib/tests/flex/cwx.spec.ts
+++ b/packages/flexlib/tests/flex/cwx.spec.ts
@@ -91,7 +91,7 @@ describe("CWX controller", () => {
 
     // when we send text
     await cwx.send("CQ CQ CQ");
-    expect(connection.lastCommand()).toBe('cwx send "CQ CQ CQ"');
+    expect(connection.lastCommand()).toBe('cwx send "CQ\x7fCQ\x7fCQ"');
 
     // when we erase
     await cwx.erase(3);
@@ -100,6 +100,20 @@ describe("CWX controller", () => {
     // when we clear the buffer
     await cwx.clearBuffer();
     expect(connection.lastCommand()).toBe("cwx clear");
+  });
+
+  it("escapes spaces in send text as DEL (0x7f)", async () => {
+    // given a connected radio with cwx
+    const { radio, connection } = await createConnectedRadio();
+    connection.emitStatus("S1|cwx wpm=20");
+
+    // when send text contains spaces
+    await radio.cwx().send("hello world test");
+    expect(connection.lastCommand()).toBe('cwx send "hello\x7fworld\x7ftest"');
+
+    // when send text contains no spaces
+    await radio.cwx().send("single");
+    expect(connection.lastCommand()).toBe('cwx send "single"');
   });
 
   it("clamps speed and delay values", async () => {

--- a/packages/flexlib/tests/flex/dvk.spec.ts
+++ b/packages/flexlib/tests/flex/dvk.spec.ts
@@ -81,6 +81,66 @@ describe("DVK snapshot", () => {
     expect(dvk?.statusRecordingId).toBe("1");
   });
 
+  it("forces status to disabled when enabled=0 arrives alone", () => {
+    // given a store with active playback
+    const store = createRadioStateStore();
+    store.apply(makeStatus("S1|dvk status=playback enabled=1 id=5"));
+    expect(store.getDvk()?.status).toBe("playback");
+    expect(store.getDvk()?.statusRecordingId).toBe("5");
+
+    // when enabled=0 arrives without status/id
+    store.apply(makeStatus("S2|dvk enabled=0"));
+
+    // then status is forced to disabled and recordingId cleared
+    const dvk = store.getDvk();
+    expect(dvk?.enabled).toBe(false);
+    expect(dvk?.status).toBe("disabled");
+    expect(dvk?.statusRecordingId).toBeUndefined();
+  });
+
+  it("overrides status when enabled=0 arrives with status and id in same message", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when a contradictory message arrives
+    store.apply(makeStatus("S1|dvk status=playback enabled=0 id=5"));
+
+    // then enabled=0 wins and forces disabled with cleared id
+    const dvk = store.getDvk();
+    expect(dvk?.enabled).toBe(false);
+    expect(dvk?.status).toBe("disabled");
+    expect(dvk?.statusRecordingId).toBeUndefined();
+  });
+
+  it("does not override when enabled=1 arrives with status and id", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when enabled=1 arrives with playback status
+    store.apply(makeStatus("S1|dvk status=playback enabled=1 id=5"));
+
+    // then status and id are preserved
+    const dvk = store.getDvk();
+    expect(dvk?.enabled).toBe(true);
+    expect(dvk?.status).toBe("playback");
+    expect(dvk?.statusRecordingId).toBe("5");
+  });
+
+  it("does not override when enabled key is absent", () => {
+    // given a store in playback
+    const store = createRadioStateStore();
+    store.apply(makeStatus("S1|dvk status=playback enabled=1 id=5"));
+
+    // when a status-only update arrives without enabled key
+    store.apply(makeStatus("S2|dvk status=idle"));
+
+    // then enabled is unchanged and status/id are not forced
+    const dvk = store.getDvk();
+    expect(dvk?.enabled).toBe(true);
+    expect(dvk?.status).toBe("idle");
+    expect(dvk?.statusRecordingId).toBe("5");
+  });
+
   it("snapshot includes dvk", () => {
     // given a store with dvk state
     const store = createRadioStateStore();

--- a/packages/flexlib/tests/flex/feature-license.spec.ts
+++ b/packages/flexlib/tests/flex/feature-license.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { makeStatus } from "../helpers.js";
+import { createRadioStateStore } from "../../src/flex/state/index.js";
+
+function futureDate(): string {
+  return new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function pastDate(): string {
+  return new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe("FeatureLicense subscription expiration", () => {
+  it("marks smartsdr+ active when expiration is in the future", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when an unexpired smartsdr+ subscription arrives
+    store.apply(
+      makeStatus(
+        `S1|license subscription name=smartsdr+ expiration=${futureDate()}`,
+      ),
+    );
+
+    // then the plus flag is active
+    const license = store.getFeatureLicense();
+    expect(license?.smartSdrPlusActive).toBe(true);
+    expect(license?.smartSdrPlusExpiration).toBeDefined();
+  });
+
+  it("marks smartsdr+ inactive when expiration is in the past", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when an expired smartsdr+ subscription arrives
+    store.apply(
+      makeStatus(
+        `S1|license subscription name=smartsdr+ expiration=${pastDate()}`,
+      ),
+    );
+
+    // then the plus flag is inactive
+    const license = store.getFeatureLicense();
+    expect(license?.smartSdrPlusActive).toBe(false);
+    expect(license?.smartSdrPlusExpiration).toBeDefined();
+  });
+
+  it("marks smartsdr+ early access active when expiration is in the future", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when an unexpired early access subscription arrives
+    store.apply(
+      makeStatus(
+        `S1|license subscription name=smartsdr+_early_access expiration=${futureDate()}`,
+      ),
+    );
+
+    // then the early access flag is active
+    const license = store.getFeatureLicense();
+    expect(license?.smartSdrPlusEarlyAccessActive).toBe(true);
+    expect(license?.smartSdrPlusEarlyAccessExpiration).toBeDefined();
+  });
+
+  it("marks smartsdr+ early access inactive when expiration is in the past", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when an expired early access subscription arrives
+    store.apply(
+      makeStatus(
+        `S1|license subscription name=smartsdr+_early_access expiration=${pastDate()}`,
+      ),
+    );
+
+    // then the early access flag is inactive
+    const license = store.getFeatureLicense();
+    expect(license?.smartSdrPlusEarlyAccessActive).toBe(false);
+    expect(license?.smartSdrPlusEarlyAccessExpiration).toBeDefined();
+  });
+
+  it("marks smartsdr+ inactive when expiration is missing", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when a smartsdr+ subscription arrives without an expiration
+    store.apply(makeStatus("S1|license subscription name=smartsdr+"));
+
+    // then the plus flag is inactive
+    const license = store.getFeatureLicense();
+    expect(license?.smartSdrPlusActive).toBe(false);
+    expect(license?.smartSdrPlusExpiration).toBeUndefined();
+  });
+
+  it("marks smartsdr+ inactive when expiration is unparseable", () => {
+    // given a fresh store
+    const store = createRadioStateStore();
+
+    // when a smartsdr+ subscription arrives with an unparseable expiration
+    store.apply(
+      makeStatus("S1|license subscription name=smartsdr+ expiration=not-a-date"),
+    );
+
+    // then the plus flag is inactive
+    const license = store.getFeatureLicense();
+    expect(license?.smartSdrPlusActive).toBe(false);
+    expect(license?.smartSdrPlusExpiration).toBeUndefined();
+  });
+});

--- a/packages/flexlib/tests/flex/radio.spec.ts
+++ b/packages/flexlib/tests/flex/radio.spec.ts
@@ -220,6 +220,45 @@ describe("Radio", () => {
     expect(stream.radioAck).toBe(true);
   });
 
+  it.each([
+    { input: 50, expected: 50 },
+    { input: 150, expected: 100 },
+    { input: -10, expected: 0 },
+  ])(
+    "clamps dax rx gain and resolves slice letter to numeric id: setRxGain($input) → $expected",
+    async ({ input, expected }) => {
+      const { radio, connection } = await createConnectedRadio();
+      // slice 1 has display letter B
+      connection.emitStatus("S1|slice 1 index_letter=B");
+      connection.prepareResponse("stream create", { message: "2000002" });
+      const creationPromise = radio.createDaxRxAudioStream({ daxChannel: 3 });
+      // stream status reports slice binding as the letter
+      connection.emitStatus(
+        "S1|stream 0x02000002 type=dax_rx dax_channel=3 slice=B client_handle=0x9ABC",
+      );
+      const stream = await creationPromise;
+
+      await stream.setRxGain(input);
+
+      // wire command sends the numeric slice id, not the letter
+      expect(connection.lastCommand()).toBe(
+        `audio stream 0x02000002 slice 1 gain ${expected}`,
+      );
+    },
+  );
+
+  it("throws when setting dax rx gain on a stream with no slice bound", async () => {
+    const { radio, connection } = await createConnectedRadio();
+    connection.prepareResponse("stream create", { message: "2000002" });
+    const creationPromise = radio.createDaxRxAudioStream({ daxChannel: 3 });
+    connection.emitStatus(
+      "S1|stream 0x02000002 type=dax_rx dax_channel=3 client_handle=0x9ABC",
+    );
+    const stream = await creationPromise;
+
+    await expect(stream.setRxGain(50)).rejects.toThrow(/no slice bound/);
+  });
+
   it("creates dax tx audio stream controllers and requests tx ownership", async () => {
     const { radio, connection } = await createConnectedRadio();
 

--- a/packages/flexlib/tests/flex/radio.spec.ts
+++ b/packages/flexlib/tests/flex/radio.spec.ts
@@ -435,6 +435,14 @@ describe("Radio", () => {
     expect(connection.lastCommand()).toBe("radio gps uninstall");
   });
 
+  it("issues a radio reboot command", async () => {
+    const { radio, connection } = await createConnectedRadio();
+
+    await radio.rebootRadio();
+
+    expect(connection.lastCommand()).toBe("radio reboot");
+  });
+
   it("emits disconnected reason when another client forces us off", async () => {
     const { radio, connection } = await createConnectedRadio();
     const reasons: Array<string | undefined> = [];

--- a/packages/flexlib/tests/flex/radio.spec.ts
+++ b/packages/flexlib/tests/flex/radio.spec.ts
@@ -424,17 +424,6 @@ describe("Radio", () => {
     expect(connection.lastCommand()).toBe("atu clear");
   });
 
-  it("issues gps install and uninstall commands", async () => {
-    const { radio, connection } = await createConnectedRadio();
-
-    // GPS commands go through the generic command interface
-    await radio.command("radio gps install");
-    expect(connection.lastCommand()).toBe("radio gps install");
-
-    await radio.command("radio gps uninstall");
-    expect(connection.lastCommand()).toBe("radio gps uninstall");
-  });
-
   it("issues a radio reboot command", async () => {
     const { radio, connection } = await createConnectedRadio();
 

--- a/packages/flexlib/tests/flex/state.spec.ts
+++ b/packages/flexlib/tests/flex/state.spec.ts
@@ -247,12 +247,12 @@ describe("createRadioStateStore", () => {
     );
     store.apply(
       makeStatus(
-        "S1|license subscription name=smartsdr+ expiration=2025-03-15T00:00:00Z",
+        "S1|license subscription name=smartsdr+ expiration=2099-03-15T00:00:00Z",
       ),
     );
     store.apply(
       makeStatus(
-        "S1|license subscription name=smartsdr+_early_access expiration=2025-04-15T00:00:00Z",
+        "S1|license subscription name=smartsdr+_early_access expiration=2099-04-15T00:00:00Z",
       ),
     );
 
@@ -263,11 +263,11 @@ describe("createRadioStateStore", () => {
     expect(license?.features["auto_tune"]?.reason).toBe("plus");
     expect(license?.smartSdrPlusActive).toBe(true);
     expect(license?.smartSdrPlusExpiration?.toISOString()).toBe(
-      "2025-03-15T00:00:00.000Z",
+      "2099-03-15T00:00:00.000Z",
     );
     expect(license?.smartSdrPlusEarlyAccessActive).toBe(true);
     expect(license?.smartSdrPlusEarlyAccessExpiration?.toISOString()).toBe(
-      "2025-04-15T00:00:00.000Z",
+      "2099-04-15T00:00:00.000Z",
     );
   });
 

--- a/packages/flexlib/tests/flex/xvtr.spec.ts
+++ b/packages/flexlib/tests/flex/xvtr.spec.ts
@@ -314,18 +314,30 @@ describe("XVTR controller", () => {
     expect(controller.id).toBe("1");
   });
 
-  it("clamps max power to minimum of -10 dBm", async () => {
-    // given a connected radio with an xvtr
-    const { radio, connection } = await createConnectedRadio();
-    connection.emitStatus(
-      "S1|xvtr 0 name=2M rf_freq=144.000000 if_freq=28.000000 max_power=5.00",
-    );
-    const controller = radio.xvtr("0")!;
+  // setMaxPowerDbm matches the official lib's clamp matrix (Xvtr.cs:170-209):
+  // the radio doesn't validate max_power so the client must clamp by model + IF freq.
+  it.each([
+    { model: "FLEX-6400", ifFreqMHz: 28, input: 20, expected: "10.00" },
+    { model: "FLEX-6600M", ifFreqMHz: 28, input: 50, expected: "10.00" },
+    { model: "FLEX-6500", ifFreqMHz: 28, input: 20, expected: "15.00" },
+    { model: "FLEX-8600", ifFreqMHz: 28, input: 20, expected: "15.00" },
+    { model: "FLEX-6400", ifFreqMHz: 100, input: 20, expected: "8.00" },
+    { model: "FLEX-6400", ifFreqMHz: 28, input: 5, expected: "5.00" },
+    { model: "FLEX-6400", ifFreqMHz: 28, input: -20, expected: "-10.00" },
+  ])(
+    "clamps max power: $model + IF=$ifFreqMHz MHz, input=$input → $expected",
+    async ({ model, ifFreqMHz, input, expected }) => {
+      const { radio, connection } = await createConnectedRadio();
+      connection.emitStatus(`S1|radio model=${model}`);
+      connection.emitStatus(
+        `S2|xvtr 0 name=2M rf_freq=144.000000 if_freq=${ifFreqMHz}.000000 max_power=0.00`,
+      );
 
-    // when we set max power below -10
-    await controller.setMaxPowerDbm(-20);
+      await radio.xvtr("0")!.setMaxPowerDbm(input);
 
-    // then it is clamped to -10
-    expect(connection.lastCommand()).toBe("xvtr set 0 max_power=-10.00");
-  });
+      expect(connection.lastCommand()).toBe(
+        `xvtr set 0 max_power=${expected}`,
+      );
+    },
+  );
 });


### PR DESCRIPTION
- Fix SmartSDR+ expiration: gate `smartSdrPlusActive` on expiration vs current time. Was always-true on receipt of `subscription` status.
- Fix CWX `send`: encode spaces as `\x7f` (DEL) before sending. Without this, the radio's tokenizer swallowed words after the first space.
- Fix DVK disabled status: when `enabled=0` arrives, force `status: "disabled"` and clear `statusRecordingId`. Was leaving stale `status: "playback"` on
disabled DVKs.
- Fix xvtr `setMaxPowerDbm`: port the C# model + IF clamp matrix (10 dBm cap on 6400/6600 below 80 MHz IF, 15 dBm for other models below 80, 8 dBm above 80,
-10 floor). Radio doesn't validate this value, so the client must clamp.
- Fix DAX RX gain: resolve slice letter to numeric id when sending `audio stream <id> slice <n> gain <n>`. Radio status reports the slice as a letter (e.g.
`B`); the gain wire command expects the numeric index. Previously sent the letter directly, which only worked for slice A by accident of lenient radio
parsing.
- Remove stray `console.log` from `FeatureLicenseController.refreshLicenseState`.
- Add `Radio.rebootRadio()` wrapping `radio reboot`.
- Add `Radio.gpsInstall()` / `Radio.gpsUninstall()` wrapping the radio's GPS install/uninstall commands.
- Add `DaxRxAudioStreamController.setRxGain(0..100)` for per-channel DAX RX gain. Throws if the stream isn't bound to a slice.
