### PR TITLE
Audio Settings Improvements

### DIFF
--- a/apps/web/src/components/settings/audio-settings.tsx
+++ b/apps/web/src/components/settings/audio-settings.tsx
@@ -1,7 +1,7 @@
 import { usePreferences } from "../../context/preferences";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { SimpleSwitch } from "../ui/simple-switch";
-import { createEffect, createSignal, Match, Show, Switch } from "solid-js";
+import { createEffect, Match, Show, Switch } from "solid-js";
 import useFlexRadio from "~/context/flexradio";
 import { DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import {
@@ -33,31 +33,14 @@ import MdiHeadphones from "~icons/mdi/headphones";
 import MdiHeadphonesOff from "~icons/mdi/headphones-off";
 import { Dynamic } from "solid-js/web";
 
+const supportedConstraints = navigator.mediaDevices.getSupportedConstraints();
+
 function InnerAudioSettings() {
   const { remoteAudioTxStream, remoteAudioRxStream } = useAudio();
   const { preferences, setPreferences } = usePreferences();
-  const [caps, setCaps] = createSignal<string[]>([]);
 
   const outputs = createSpeakers();
   const inputs = createMicrophones();
-
-  createEffect(() => {
-    navigator.mediaDevices
-      .getUserMedia({
-        audio: {
-          deviceId: preferences.remoteAudio.tx.inputDeviceId,
-        },
-      })
-      .then((stream) => {
-        for (const track of stream.getTracks()) {
-          setCaps(Object.keys(track.getCapabilities()));
-          track.stop();
-        }
-      })
-      .catch((reason) =>
-        console.error("Failed get device capabilities:", reason),
-      );
-  });
 
   return (
     <Card class="bg-transparent">
@@ -149,43 +132,41 @@ function InnerAudioSettings() {
           <SelectContent />
         </Select>
         <AudioLevelMeter stream={remoteAudioTxStream()} channelMode="both" />
-        <Show when={caps().length} fallback="Checking capabilities...">
-          <Show when={caps().includes("autoGainControl")}>
-            <SimpleSwitch
-              checked={preferences.remoteAudio.tx.autoGainControl}
-              onChange={(checked) =>
-                setPreferences("remoteAudio", "tx", "autoGainControl", checked)
-              }
-              label="Auto Gain Control"
-            />
-          </Show>
-          <Show when={caps().includes("echoCancellation")}>
-            <SimpleSwitch
-              checked={preferences.remoteAudio.tx.echoCancellation}
-              onChange={(checked) =>
-                setPreferences("remoteAudio", "tx", "echoCancellation", checked)
-              }
-              label="Echo Cancellation"
-            />
-          </Show>
-          <Show when={caps().includes("noiseSuppression")}>
-            <SimpleSwitch
-              checked={preferences.remoteAudio.tx.noiseSuppression}
-              onChange={(checked) =>
-                setPreferences("remoteAudio", "tx", "noiseSuppression", checked)
-              }
-              label="Noise Suppression"
-            />
-          </Show>
-          <Show when={caps().includes("voiceIsolation")}>
-            <SimpleSwitch
-              checked={preferences.remoteAudio.tx.voiceIsolation}
-              onChange={(checked) =>
-                setPreferences("remoteAudio", "tx", "voiceIsolation", checked)
-              }
-              label="Voice Isolation"
-            />
-          </Show>
+        <Show when={supportedConstraints?.autoGainControl}>
+          <SimpleSwitch
+            checked={preferences.remoteAudio.tx.autoGainControl}
+            onChange={(checked) =>
+              setPreferences("remoteAudio", "tx", "autoGainControl", checked)
+            }
+            label="Auto Gain Control"
+          />
+        </Show>
+        <Show when={supportedConstraints?.echoCancellation}>
+          <SimpleSwitch
+            checked={preferences.remoteAudio.tx.echoCancellation}
+            onChange={(checked) =>
+              setPreferences("remoteAudio", "tx", "echoCancellation", checked)
+            }
+            label="Echo Cancellation"
+          />
+        </Show>
+        <Show when={supportedConstraints?.noiseSuppression}>
+          <SimpleSwitch
+            checked={preferences.remoteAudio.tx.noiseSuppression}
+            onChange={(checked) =>
+              setPreferences("remoteAudio", "tx", "noiseSuppression", checked)
+            }
+            label="Noise Suppression"
+          />
+        </Show>
+        <Show when={supportedConstraints?.voiceIsolation}>
+          <SimpleSwitch
+            checked={preferences.remoteAudio.tx.voiceIsolation}
+            onChange={(checked) =>
+              setPreferences("remoteAudio", "tx", "voiceIsolation", checked)
+            }
+            label="Voice Isolation"
+          />
         </Show>
       </CardContent>
     </Card>
@@ -197,10 +178,11 @@ export function AudioSettings() {
   const audioPermission = createPermission("microphone");
 
   createEffect(() => {
-    if (audioPermission() === "unknown")
+    if (audioPermission() === "prompt") {
       navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
         stream.getTracks().forEach((track) => track.stop());
       });
+    }
   });
 
   return (

--- a/apps/web/src/components/settings/dax-iq-settings.tsx
+++ b/apps/web/src/components/settings/dax-iq-settings.tsx
@@ -1,6 +1,6 @@
 import { usePreferences } from "../../context/preferences";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { For, Show } from "solid-js";
+import { createEffect, For, Match, Show, Switch } from "solid-js";
 import useFlexRadio from "~/context/flexradio";
 import { DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import {
@@ -18,8 +18,10 @@ import {
   SwitchLabel,
   SwitchThumb,
 } from "../ui/switch";
+import { createPermission } from "~/lib/permission";
+import { Callout, CalloutContent, CalloutTitle } from "../ui/callout";
 
-export function DaxIqSettings() {
+export function InnerDaxIqSettings() {
   const { preferences, setPreferences } = usePreferences();
   const { radio } = useFlexRadio();
   const outputs = createSpeakers();
@@ -28,120 +30,154 @@ export function DaxIqSettings() {
   const sampleRates = () => radio()?.modelInfo.daxIqSampleRates ?? [];
 
   return (
+    <div
+      class="relative flex flex-col gap-4 text-sm overflow-y-auto shrink"
+      style={{ "scrollbar-width": "thin" }}
+    >
+      <Show
+        when={maxChannels() > 0}
+        fallback={
+          <div class="text-muted-foreground">
+            This radio does not support DAX IQ.
+          </div>
+        }
+      >
+        <For each={Array.from({ length: maxChannels() }, (_, i) => i + 1)}>
+          {(channel) => {
+            return (
+              <Card class="bg-transparent">
+                <CardHeader>
+                  <SwitchRoot
+                    class="flex"
+                    checked={preferences.dax.iq[channel]?.enabled ?? false}
+                    onChange={(checked) =>
+                      setPreferences("dax", "iq", channel, "enabled", checked)
+                    }
+                  >
+                    <SwitchLabel class="grow flex items-center">
+                      <CardTitle>DAX IQ {channel}</CardTitle>
+                    </SwitchLabel>
+                    <SwitchControl>
+                      <SwitchThumb />
+                    </SwitchControl>
+                  </SwitchRoot>
+                </CardHeader>
+                <CardContent class="flex flex-col gap-4">
+                  <div class="flex gap-2">
+                    <Select
+                      class="flex flex-col gap-2 grow shrink"
+                      value={preferences.dax.iq[channel]?.outputDeviceId}
+                      onChange={(value: string) => {
+                        if (!value) return;
+                        setPreferences(
+                          "dax",
+                          "iq",
+                          channel,
+                          "outputDeviceId",
+                          value,
+                        );
+                      }}
+                      options={outputs().map((d) => d.deviceId)}
+                      itemComponent={(props) => (
+                        <SelectItem item={props.item}>
+                          {
+                            outputs().find(
+                              (d) => d.deviceId === props.item.rawValue,
+                            )?.label
+                          }
+                        </SelectItem>
+                      )}
+                    >
+                      <SelectLabel>Output Device</SelectLabel>
+                      <div class="w-full h-10 relative">
+                        <SelectTrigger class="absolute">
+                          <SelectValue class="truncate">
+                            {(s) =>
+                              outputs().find(
+                                (d) => d.deviceId === s.selectedOption(),
+                              )?.label || "Select Audio Output"
+                            }
+                          </SelectValue>
+                        </SelectTrigger>
+                      </div>
+                      <SelectContent />
+                    </Select>
+                    <Select<number>
+                      class="flex flex-col gap-2"
+                      value={preferences.dax.iq[channel]?.sampleRate}
+                      onChange={(value: number | null) => {
+                        if (!value) return;
+                        setPreferences(
+                          "dax",
+                          "iq",
+                          channel,
+                          "sampleRate",
+                          value,
+                        );
+                      }}
+                      options={[...sampleRates()]}
+                      itemComponent={(props) => (
+                        <SelectItem item={props.item}>
+                          {(props.item.rawValue / 1000).toString()} kHz
+                        </SelectItem>
+                      )}
+                    >
+                      <SelectLabel>Sample Rate</SelectLabel>
+                      <SelectTrigger>
+                        <SelectValue<number> class="truncate">
+                          {(s) =>
+                            `${(s.selectedOption() / 1000).toString()} kHz`
+                          }
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent />
+                    </Select>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          }}
+        </For>
+      </Show>
+    </div>
+  );
+}
+
+export function DaxIqSettings() {
+  const audioPermission = createPermission("microphone");
+
+  createEffect(() => {
+    if (audioPermission() === "prompt")
+      navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
+        stream.getTracks().forEach((track) => track.stop());
+      });
+  });
+
+  return (
     <DialogContent class="translate-y-0 top-1/12 flex flex-col max-h-10/12 overflow-hidden">
       <DialogHeader>
         <DialogTitle>DAX IQ Settings</DialogTitle>
       </DialogHeader>
-      <div
-        class="relative flex flex-col gap-4 text-sm overflow-y-auto shrink"
-        style={{ "scrollbar-width": "thin" }}
+      <Switch
+        fallback={
+          <Callout>
+            <CalloutTitle>Audio Permissions Required</CalloutTitle>
+            <CalloutContent>Waiting for Audio Permissions...</CalloutContent>
+          </Callout>
+        }
       >
-        <Show
-          when={maxChannels() > 0}
-          fallback={
-            <div class="text-muted-foreground">
-              This radio does not support DAX IQ.
-            </div>
-          }
-        >
-          <For each={Array.from({ length: maxChannels() }, (_, i) => i + 1)}>
-            {(channel) => {
-              return (
-                <Card class="bg-transparent">
-                  <CardHeader>
-                    <SwitchRoot
-                      class="flex"
-                      checked={preferences.dax.iq[channel]?.enabled ?? false}
-                      onChange={(checked) =>
-                        setPreferences("dax", "iq", channel, "enabled", checked)
-                      }
-                    >
-                      <SwitchLabel class="grow flex items-center">
-                        <CardTitle>DAX IQ {channel}</CardTitle>
-                      </SwitchLabel>
-                      <SwitchControl>
-                        <SwitchThumb />
-                      </SwitchControl>
-                    </SwitchRoot>
-                  </CardHeader>
-                  <CardContent class="flex flex-col gap-4">
-                    <div class="flex gap-2">
-                      <Select
-                        class="flex flex-col gap-2 grow shrink"
-                        value={preferences.dax.iq[channel]?.outputDeviceId}
-                        onChange={(value: string) => {
-                          if (!value) return;
-                          setPreferences(
-                            "dax",
-                            "iq",
-                            channel,
-                            "outputDeviceId",
-                            value,
-                          );
-                        }}
-                        options={outputs().map((d) => d.deviceId)}
-                        itemComponent={(props) => (
-                          <SelectItem item={props.item}>
-                            {
-                              outputs().find(
-                                (d) => d.deviceId === props.item.rawValue,
-                              )?.label
-                            }
-                          </SelectItem>
-                        )}
-                      >
-                        <SelectLabel>Output Device</SelectLabel>
-                        <div class="w-full h-10 relative">
-                          <SelectTrigger class="absolute">
-                            <SelectValue class="truncate">
-                              {(s) =>
-                                outputs().find(
-                                  (d) => d.deviceId === s.selectedOption(),
-                                )?.label || "Select Audio Output"
-                              }
-                            </SelectValue>
-                          </SelectTrigger>
-                        </div>
-                        <SelectContent />
-                      </Select>
-                      <Select<number>
-                        class="flex flex-col gap-2"
-                        value={preferences.dax.iq[channel]?.sampleRate}
-                        onChange={(value: number | null) => {
-                          if (!value) return;
-                          setPreferences(
-                            "dax",
-                            "iq",
-                            channel,
-                            "sampleRate",
-                            value,
-                          );
-                        }}
-                        options={[...sampleRates()]}
-                        itemComponent={(props) => (
-                          <SelectItem item={props.item}>
-                            {(props.item.rawValue / 1000).toString()} kHz
-                          </SelectItem>
-                        )}
-                      >
-                        <SelectLabel>Sample Rate</SelectLabel>
-                        <SelectTrigger>
-                          <SelectValue<number> class="truncate">
-                            {(s) =>
-                              `${(s.selectedOption() / 1000).toString()} kHz`
-                            }
-                          </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent />
-                      </Select>
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            }}
-          </For>
-        </Show>
-      </div>
+        <Match when={audioPermission() === "granted"}>
+          <InnerDaxIqSettings />
+        </Match>
+        <Match when={audioPermission() === "denied"}>
+          <Callout variant="error">
+            <CalloutTitle>Audio Permissions Denied</CalloutTitle>
+            <CalloutContent>
+              You must grant audio permissions to use DAX IQ features.
+            </CalloutContent>
+          </Callout>
+        </Match>
+      </Switch>
     </DialogContent>
   );
 }

--- a/apps/web/src/components/settings/dax-settings.tsx
+++ b/apps/web/src/components/settings/dax-settings.tsx
@@ -1,7 +1,7 @@
 import { usePreferences } from "../../context/preferences";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { SimpleSwitch } from "../ui/simple-switch";
-import { createEffect, createSignal, For, Match, Show, Switch } from "solid-js";
+import { createEffect, For, Match, Show, Switch } from "solid-js";
 import useFlexRadio from "~/context/flexradio";
 import { DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import {
@@ -36,32 +36,15 @@ const CHANNEL_MODE_ICONS = {
   both: Stereo,
 };
 
+const supportedConstraints = navigator.mediaDevices.getSupportedConstraints();
+
 function InnerDaxSettings() {
   const { daxSinks, daxTxStream } = useAudio();
   const { preferences, setPreferences } = usePreferences();
   const { state } = useFlexRadio();
-  const [caps, setCaps] = createSignal<string[]>([]);
 
   const outputs = createSpeakers();
   const inputs = createMicrophones();
-
-  createEffect(() => {
-    navigator.mediaDevices
-      .getUserMedia({
-        audio: {
-          deviceId: preferences.dax.tx.inputDeviceId,
-        },
-      })
-      .then((stream) => {
-        for (const track of stream.getTracks()) {
-          setCaps(Object.keys(track.getCapabilities()));
-          track.stop();
-        }
-      })
-      .catch((reason) =>
-        console.error("Failed get device capabilities:", reason),
-      );
-  });
 
   return (
     <div
@@ -159,43 +142,41 @@ function InnerDaxSettings() {
             }
             label="Reduced Bandwidth"
           />
-          <Show when={caps().length} fallback="Checking capabilities...">
-            <Show when={caps().includes("autoGainControl")}>
-              <SimpleSwitch
-                checked={preferences.dax.tx.autoGainControl}
-                onChange={(checked) =>
-                  setPreferences("dax", "tx", "autoGainControl", checked)
-                }
-                label="Auto Gain Control"
-              />
-            </Show>
-            <Show when={caps().includes("echoCancellation")}>
-              <SimpleSwitch
-                checked={preferences.dax.tx.echoCancellation}
-                onChange={(checked) =>
-                  setPreferences("dax", "tx", "echoCancellation", checked)
-                }
-                label="Echo Cancellation"
-              />
-            </Show>
-            <Show when={caps().includes("noiseSuppression")}>
-              <SimpleSwitch
-                checked={preferences.dax.tx.noiseSuppression}
-                onChange={(checked) =>
-                  setPreferences("dax", "tx", "noiseSuppression", checked)
-                }
-                label="Noise Suppression"
-              />
-            </Show>
-            <Show when={caps().includes("voiceIsolation")}>
-              <SimpleSwitch
-                checked={preferences.dax.tx.voiceIsolation}
-                onChange={(checked) =>
-                  setPreferences("dax", "tx", "voiceIsolation", checked)
-                }
-                label="Voice Isolation"
-              />
-            </Show>
+          <Show when={supportedConstraints?.autoGainControl}>
+            <SimpleSwitch
+              checked={preferences.dax.tx.autoGainControl}
+              onChange={(checked) =>
+                setPreferences("dax", "tx", "autoGainControl", checked)
+              }
+              label="Auto Gain Control"
+            />
+          </Show>
+          <Show when={supportedConstraints?.echoCancellation}>
+            <SimpleSwitch
+              checked={preferences.dax.tx.echoCancellation}
+              onChange={(checked) =>
+                setPreferences("dax", "tx", "echoCancellation", checked)
+              }
+              label="Echo Cancellation"
+            />
+          </Show>
+          <Show when={supportedConstraints?.noiseSuppression}>
+            <SimpleSwitch
+              checked={preferences.dax.tx.noiseSuppression}
+              onChange={(checked) =>
+                setPreferences("dax", "tx", "noiseSuppression", checked)
+              }
+              label="Noise Suppression"
+            />
+          </Show>
+          <Show when={supportedConstraints?.voiceIsolation}>
+            <SimpleSwitch
+              checked={preferences.dax.tx.voiceIsolation}
+              onChange={(checked) =>
+                setPreferences("dax", "tx", "voiceIsolation", checked)
+              }
+              label="Voice Isolation"
+            />
           </Show>
         </CardContent>
       </Card>
@@ -325,7 +306,7 @@ export function DaxSettings() {
   const audioPermission = createPermission("microphone");
 
   createEffect(() => {
-    if (audioPermission() === "unknown")
+    if (audioPermission() === "prompt")
       navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
         stream.getTracks().forEach((track) => track.stop());
       });

--- a/apps/web/src/components/settings/index.tsx
+++ b/apps/web/src/components/settings/index.tsx
@@ -1,6 +1,4 @@
-import {
-  Dialog,
-} from "../ui/dialog";
+import { Dialog } from "../ui/dialog";
 import MdiSettings from "~icons/mdi/settings";
 import { AppSettings } from "./app-settings";
 import { RadioSettings } from "./radio-settings";
@@ -25,6 +23,7 @@ import { WaveformSettings } from "./waveform-settings";
 import { Meters } from "./meters";
 import { ProfileSettings } from "./profile-settings";
 import { ImportExport } from "./import-export";
+import useFlexRadio from "~/context/flexradio";
 
 const tabs = {
   app: AppSettings,
@@ -45,6 +44,8 @@ const tabs = {
 
 export function Settings() {
   const [activeTab, setActiveTab] = createSignal(null);
+  const { state } = useFlexRadio();
+  const disconnected = () => !state.clientHandle;
   return (
     <>
       <Dialog
@@ -64,43 +65,76 @@ export function Settings() {
           <DropdownMenuItem onSelect={() => setActiveTab("app")}>
             App Settings
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("radio")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("radio")}
+          >
             Radio Setup
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("memory")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("memory")}
+          >
             Memory
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("spots")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("spots")}
+          >
             Spots
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setActiveTab("midi")}>
             MIDI Controllers
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("dax")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("dax")}
+          >
             DAX Settings
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("daxIq")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("daxIq")}
+          >
             DAX IQ Settings
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setActiveTab("audio")}>
             Audio Settings
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("multiflex")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("multiflex")}
+          >
             multiFLEX
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("network")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("network")}
+          >
             Network Stats
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("waveform")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("waveform")}
+          >
             Waveforms
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("meters")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("meters")}
+          >
             Meters
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("profiles")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("profiles")}
+          >
             Profiles
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setActiveTab("import/export")}>
+          <DropdownMenuItem
+            disabled={disconnected()}
+            onSelect={() => setActiveTab("import/export")}
+          >
             Import/Export
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/context/audio.tsx
+++ b/apps/web/src/context/audio.tsx
@@ -81,6 +81,7 @@ export const AudioProvider: ParentComponent = (props) => {
       preferences.remoteAudio.rx.enabled ||
       preferences.dax.tx.enabled ||
       Object.values(preferences.dax.rx).some((c) => c.enabled);
+    Object.values(preferences.dax.iq).some((c) => c.enabled);
     if (!audioEnabled) return;
     navigator.mediaDevices
       .getUserMedia({ audio: true })
@@ -274,7 +275,8 @@ export const AudioProvider: ParentComponent = (props) => {
     // go through setSampleRate (in the rate-sync effect below) instead of
     // tearing the stream down and recreating it.
     createEffect(() => {
-      if (!state.clientHandle || !preferences.dax.iq[iqChannel]?.enabled) return;
+      if (!state.clientHandle || !preferences.dax.iq[iqChannel]?.enabled)
+        return;
       const initialRate = untrack(
         () => preferences.dax.iq[iqChannel].sampleRate,
       );

--- a/apps/web/src/lib/permission.ts
+++ b/apps/web/src/lib/permission.ts
@@ -1,83 +1,90 @@
-import {
-  type Accessor,
-  createEffect,
-  createSignal,
-  on,
-  onCleanup,
-} from "solid-js";
+import { ReactiveMap } from "@kobalte/utils";
+import { type Accessor, createSignal } from "solid-js";
 import { isServer } from "solid-js/web";
+
+type PermissionInput =
+  | PermissionDescriptor
+  | PermissionName
+  | "microphone"
+  | "camera";
+
+const cache = new ReactiveMap<string, Accessor<PermissionState | "unknown">>();
+
+const cacheKey = (name: PermissionInput): string =>
+  typeof name === "string" ? name : JSON.stringify(name);
 
 /**
  * Querying the permission API
+ *
+ * Memoized per permission name at module scope, so the first caller triggers
+ * the underlying `navigator.permissions.query` (and any Firefox getUserMedia
+ * wrapping) once, and later callers — including dialogs that mount after a
+ * permission has already been granted — receive the current state immediately
+ * instead of starting at "unknown".
  *
  * @param name permission name (e.g. "microphone") or a PermissionDescriptor object (`{ name: ... }`)
  * @returns "unknown" | "denied" | "granted" | "prompt"
  */
 export const createPermission = (
-  name: PermissionDescriptor | PermissionName | "microphone" | "camera",
+  name: PermissionInput,
 ): Accessor<PermissionState | "unknown"> => {
   if (isServer) {
     return () => "unknown";
   }
+  const key = cacheKey(name);
+  const cached = cache.get(key);
+  if (cached) return cached;
+
   const [permission, setPermission] = createSignal<PermissionState | "unknown">(
     "unknown",
   );
-  const [status, setStatus] = createSignal<PermissionStatus>();
-   
-  if (navigator) {
-    navigator.permissions
-      .query(typeof name === "string" ? { name } : name)
-      .then(setStatus)
-      .catch((error) => {
-        if (
-          error.name !== "TypeError" ||
-          (name !== "microphone" && name !== "camera")
-        ) {
-          return;
-        }
-        // firefox will not allow us to read media permissions,
-        // so we need to wrap getUserMedia in order to get them:
-        // TODO: only set to prompt if devices are available
-        setPermission("prompt");
-        const constraint = name === "camera" ? "video" : "audio";
-        const getUserMedia = navigator.mediaDevices.getUserMedia.bind(
-          navigator.mediaDevices,
-        );
-        navigator.mediaDevices.getUserMedia = (constraints) =>
-          constraints?.[constraint]
-            ? getUserMedia(constraints)
-                .then((stream) => (setPermission("granted"), stream))
-                .catch((error) => {
-                  if (/not allowed/.test(error.message)) {
-                    setPermission("denied");
-                  }
-                  return Promise.reject(error);
-                })
-            : getUserMedia(constraints);
-      });
-    if (name == "microphone") {
-      const onDeviceChange = () =>
-        navigator.permissions
-          .query(typeof name === "string" ? { name } : name)
-          .then(setStatus);
-      navigator.mediaDevices.addEventListener("devicechange", onDeviceChange);
-      onCleanup(() =>
-        navigator.mediaDevices.removeEventListener(
-          "devicechange",
-          onDeviceChange,
-        ),
+  cache.set(key, permission);
+
+  if (!navigator) return permission;
+
+  const descriptor = typeof name === "string" ? { name } : name;
+
+  navigator.permissions
+    .query(descriptor)
+    .then((status) => {
+      setPermission(status.state);
+      status.addEventListener("change", () => setPermission(status.state));
+    })
+    .catch((error) => {
+      if (
+        error.name !== "TypeError" ||
+        (name !== "microphone" && name !== "camera")
+      ) {
+        return;
+      }
+      // firefox will not allow us to read media permissions,
+      // so we need to wrap getUserMedia in order to get them:
+      // TODO: only set to prompt if devices are available
+      setPermission("prompt");
+      const constraint = name === "camera" ? "video" : "audio";
+      const getUserMedia = navigator.mediaDevices.getUserMedia.bind(
+        navigator.mediaDevices,
       );
-    }
-    createEffect(
-      on(status, (status) => {
-        if (status) {
-          setPermission(status.state);
-          const listener = () => setPermission(status.state);
-          status.addEventListener("change", listener);
-          onCleanup(() => status.removeEventListener("change", listener));
-        }
-      }),
-    );
+      navigator.mediaDevices.getUserMedia = (constraints) =>
+        constraints?.[constraint]
+          ? getUserMedia(constraints)
+              .then((stream: MediaStream) => (setPermission("granted"), stream))
+              .catch((error: DOMException) => {
+                if (/not allowed/.test(error.message)) {
+                  setPermission("denied");
+                }
+                return Promise.reject(error);
+              })
+          : getUserMedia(constraints);
+    });
+
+  if (name === "microphone") {
+    navigator.mediaDevices.addEventListener("devicechange", () => {
+      navigator.permissions
+        .query(descriptor)
+        .then((status) => setPermission(status.state));
+    });
   }
+
   return permission;
 };

--- a/apps/web/src/types/global.d.ts
+++ b/apps/web/src/types/global.d.ts
@@ -9,6 +9,11 @@ declare global {
       debugOutput: string;
     }>;
   }
+
+  // Chrome-only constraint, not yet in lib.dom.
+  interface MediaTrackSupportedConstraints {
+    voiceIsolation?: boolean;
+  }
 }
 
 export {};

--- a/packages/flexlib/src/vita/dax-audio-packet.ts
+++ b/packages/flexlib/src/vita/dax-audio-packet.ts
@@ -188,7 +188,9 @@ export class VitaDaxAudioPacket {
  *
  * Payload is mono 16-bit signed integer samples (range [−32768, 32767]).
  *
- * Typical use: 128-frame blocks on a reduced-bandwidth DAX channel (e.g. 8 kHz).
+ * Same 24 kHz sample rate and 128-frame cadence as the stereo float32 variant —
+ * the "reduced bandwidth" comes from the encoding (mono int16 = 2 bytes/frame vs
+ * stereo float32 = 8 bytes/frame), giving 4× lower wire bandwidth.
  */
 export class VitaDaxReducedBwPacket {
   /** VITA-49 header word fields. */


### PR DESCRIPTION
- Audio permissions are now stored globally to prevent thrashing `getUserMedia` calls
- `getUserMedia` is now triggered on `prompt` instead of `unknown` (I think this was an artifact of an older attempt to work around Safari not handling permissions well, before we rolled our own permission notifier)
- Audio device capabilities now use a sync API instead of `getUserMedia` so there are no jarring layout changes when opening Audio or DAX settings dialogs
- Settings dialogs that require radio connection have their menu items disabled instead of each dialog having to handle the disconnected state itself.
- DAX IQ settings now have an audio permissions gate