### PR TITLE
Fix infinite reconnect loop

### DIFF
--- a/apps/server/internal/rtc/session.go
+++ b/apps/server/internal/rtc/session.go
@@ -118,6 +118,16 @@ func (cs *clientSession) serve(ctx context.Context) {
 		cs.dispatch(ctx, env)
 	}
 
+	// WS is gone — Proactively close the PC instead of waiting for the client to do it
+	cs.mu.Lock()
+	pc := cs.pc
+	cs.mu.Unlock()
+
+	if pc != nil {
+		_ = pc.Close()
+	}
+
+	cs.cancel()
 	wg.Wait()
 }
 

--- a/apps/web/src/context/rtc.tsx
+++ b/apps/web/src/context/rtc.tsx
@@ -10,12 +10,12 @@ import {
 import type { Accessor, Setter } from "solid-js";
 import { APP_VERSION } from "~/lib/version";
 import {
-  createReconnectingWS,
   createWSState,
   makeHeartbeatWS,
   type ReconnectingWebSocket,
 } from "@solid-primitives/websocket";
 import { createStore } from "solid-js/store";
+import { createReconnectingWS } from "~/lib/websocket";
 
 const RtcCtx = createContext<RtcContextValue>();
 

--- a/apps/web/src/lib/websocket.ts
+++ b/apps/web/src/lib/websocket.ts
@@ -1,0 +1,93 @@
+import {
+  makeWS,
+  ReconnectingWebSocket,
+  WSMessage,
+  WSReconnectOptions,
+} from "@solid-primitives/websocket";
+import { onCleanup } from "solid-js";
+
+/**
+ * Returns a WebSocket-like object that under the hood opens new connections on disconnect:
+ * ```ts
+ * const ws = makeReconnectingWS("ws:localhost:5000");
+ * createEffect(() => ws.send(serverMessage()));
+ * onCleanup(() => ws.close());
+ * ```
+ * Will not throw if you attempt to send messages before the connection opened; instead, it will enqueue the message to be sent when the connection opens.
+ *
+ * It will not close the connection on cleanup. To do that, use `createReconnectingWS`.
+ */
+export const makeReconnectingWS = (
+  url: string,
+  protocols?: string | string[],
+  options: WSReconnectOptions = {},
+) => {
+  let retries = options.retries || Infinity;
+  let ws: ReconnectingWebSocket;
+  const queue: WSMessage[] = [];
+  let events: Parameters<WebSocket["addEventListener"]>[] = [
+    [
+      "close",
+      () => {
+        retries-- > 0 && setTimeout(getWS, options.delay || 3000);
+      },
+    ],
+  ];
+  const getWS = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (ws && ws.readyState < 2) ws.close();
+    ws = Object.assign(makeWS(url, protocols, queue), {
+      reconnect: () => ws.close(),
+    });
+    events.forEach((args) => ws.addEventListener(...args));
+  };
+  getWS();
+  const wws: Partial<ReconnectingWebSocket> = {
+    close: (...args: Parameters<WebSocket["close"]>) => {
+      retries = 0;
+      return ws.close(...args);
+    },
+    addEventListener: (...args: Parameters<WebSocket["addEventListener"]>) => {
+      events.push(args);
+      return ws.addEventListener(...args);
+    },
+    removeEventListener: (
+      ...args: Parameters<WebSocket["removeEventListener"]>
+    ) => {
+      events = events.filter((ev) => args[0] !== ev[0] || args[1] !== ev[1]);
+      return ws.removeEventListener(...args);
+    },
+    send: (msg: WSMessage) => {
+      wws.send!.before?.();
+      return ws.send(msg);
+    },
+  };
+  for (const name in ws!)
+    wws[name as keyof typeof wws] == null &&
+      Object.defineProperty(wws, name, {
+        enumerable: true,
+        get: () =>
+          typeof ws[name as keyof typeof ws] === "function"
+            ? (ws[name as keyof typeof ws] as Function).bind(ws)
+            : ws[name as keyof typeof ws],
+      });
+  return wws as ReconnectingWebSocket;
+};
+
+/**
+ * Returns a WebSocket-like object that under the hood opens new connections on disconnect and closes on cleanup:
+ * ```ts
+ * const ws = makeReconnectingWS("ws:localhost:5000");
+ * createEffect(() => ws.send(serverMessage()));
+ * ```
+ * Will not throw if you attempt to send messages before the connection opened; instead, it will enqueue the message to be sent when the connection opens.
+ */
+export const createReconnectingWS: typeof makeReconnectingWS = (
+  url,
+  protocols,
+  options,
+) => {
+  const ws = makeReconnectingWS(url, protocols, options);
+  onCleanup(() => ws.close());
+  return ws;
+};


### PR DESCRIPTION
We were running into a bug in the solid primitives reconnecting websocket implementation. If you actually call the `reconnect()` method, it enters an infinite reconnect loop. That bug also highlighted a goroutine leak caused by the client not cleaning up its PeerConnection on a reconnect. The fix here has 2 parts:

1. Roll our own fixed version of the reconnecting websocket. (submitted upstream [report](https://github.com/solidjs-community/solid-primitives/issues/927) and [fix](https://github.com/solidjs-community/solid-primitives/pull/929))
2. Proactively clean up the PC on the server when the websocket disconnects. The frontend is supposed to do this, but in true failure scenarios it doesn't always happen and can could leaks on the server.