### PR TITLE
Mouse wheel tuning

### DIFF
--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -46,6 +46,7 @@ import { usePreferences } from "~/context/preferences";
 import { Toggle } from "../ui/toggle";
 import { PanafallControl } from "./controls";
 import { CreateProfileDialog } from "../settings/profile-settings";
+import { useControls } from "~/context/controls";
 
 type PanafallButtonProps<T extends ValidComponent = "button"> = ComponentProps<
   typeof TooltipTrigger<T>
@@ -134,6 +135,8 @@ export function Panafall(props: { index: number }) {
     panafallBounds,
     setPanafallPortalRef,
   } = usePanafall();
+
+  const { dispatch } = useControls();
 
   createEffect(
     (lastSize: { width: number; height: number }) => {
@@ -373,6 +376,25 @@ export function Panafall(props: { index: number }) {
                       "cursor-crosshair": !dragState.dragging,
                     }}
                     class="absolute inset-0 select-none touch-none"
+                    onWheel={
+                      preferences.mousewheelTuning
+                        ? (e: WheelEvent) => {
+                            e.preventDefault();
+                            const delta = (
+                              preferences.invertMousewheelTuning
+                                ? e.deltaY < 0
+                                : e.deltaY > 0
+                            )
+                              ? 1
+                              : -1;
+                            dispatch({
+                              target: "slice.frequency",
+                              op: "adjust",
+                              delta,
+                            });
+                          }
+                        : undefined
+                    }
                     onDblClick={(e: PointerEvent) => {
                       if (dragState.dragging) return;
                       setDragState("originX", 0);

--- a/apps/web/src/components/settings/app-settings.tsx
+++ b/apps/web/src/components/settings/app-settings.tsx
@@ -231,6 +231,37 @@ export function AppSettings() {
         </Card>
         <Card class="bg-transparent">
           <CardHeader>
+            <CardTitle>Controls</CardTitle>
+          </CardHeader>
+          <CardContent class="flex flex-col gap-4">
+            <SimpleSwitch
+              checked={preferences.smoothScroll}
+              onChange={(isChecked) => {
+                setPreferences("smoothScroll", isChecked);
+              }}
+              label="Smooth Scroll"
+              description="Enable smooth horizontal scrolling of the panafall."
+            />
+            <SimpleSwitch
+              checked={preferences.mousewheelTuning}
+              onChange={(isChecked) => {
+                setPreferences("mousewheelTuning", isChecked);
+              }}
+              label="Mousewheel Tuning"
+              description="Enable tuning the active slice with the mousewheel."
+            />
+            <SimpleSwitch
+              checked={preferences.invertMousewheelTuning}
+              onChange={(isChecked) => {
+                setPreferences("invertMousewheelTuning", isChecked);
+              }}
+              label="Invert Mousewheel Tuning"
+              description="Change the direction mousewheel tuning moves the frequency."
+            />
+          </CardContent>
+        </Card>
+        <Card class="bg-transparent">
+          <CardHeader>
             <CardTitle>Display</CardTitle>
           </CardHeader>
           <CardContent class="flex flex-col gap-4">
@@ -249,14 +280,6 @@ export function AppSettings() {
               }}
               label="Blur Effects"
               description="Enable the use of a blur effect on transparent UI elements"
-            />
-            <SimpleSwitch
-              checked={preferences.smoothScroll}
-              onChange={(isChecked) => {
-                setPreferences("smoothScroll", isChecked);
-              }}
-              label="Smooth Scroll"
-              description="Enable smooth horizontal scrolling of the panafall."
             />
             <SimpleSwitch
               checked={preferences.showTuningGuide}

--- a/apps/web/src/context/preferences.tsx
+++ b/apps/web/src/context/preferences.tsx
@@ -76,6 +76,8 @@ export interface SpotPreferences {
 export interface Preferences {
   stationName: string;
   smoothScroll: boolean;
+  mousewheelTuning: boolean;
+  invertMousewheelTuning: boolean;
   enableBlurEffects: boolean;
   midiMappings: MidiMapping[];
   enableTransparencyEffects: boolean;
@@ -147,6 +149,8 @@ const defaultDaxIqConfig = () => {
 const getDefaults = (): Preferences => ({
   stationName: "",
   smoothScroll: true,
+  mousewheelTuning: false,
+  invertMousewheelTuning: false,
   enableBlurEffects: true,
   enableTransparencyEffects: true,
   showDisplayMarkers: true,


### PR DESCRIPTION
## Mouse Wheel Tuning

You can now tune the active slice using the mousewheel (or scrolling on a touchpad). The behavior should match SmartSDR, but it's disabled by default and must be enabled in the App Settings.

The App Settings dialog gains a new Controls card with 2 new switches, "Mousewheel Tuning" and "Invert Mousewheel Tuning":

<img width="473" height="258" alt="image" src="https://github.com/user-attachments/assets/e375e082-e6b7-4e54-95cd-7515c393d5b5" />

