### PR TITLE
Add a way to create debug reports

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -23,12 +23,15 @@ import { Callout, CalloutContent, CalloutTitle } from "./components/ui/callout";
 import { Button } from "./components/ui/button";
 import MaterialSymbolsOpenInNew from "~icons/material-symbols/open-in-new";
 import { ReleaseNotification } from "./components/release-notification";
+import { DebugModeProvider } from "./context/debug-mode";
+import { DebugBanner } from "./components/debug-mode/banner";
 
 function AppInner() {
   const { preferences, setPreferences } = usePreferences();
   const { radio } = useFlexRadio();
   return (
     <div class="absolute inset-0 flex flex-col items-stretch">
+      <DebugBanner />
       <SidebarProvider
         class="relative grow h-auto overflow-visible min-h-0 bg-transparent"
         open={!!preferences.radioPanelOpen}
@@ -88,17 +91,19 @@ function App() {
               </Callout>
             }
           >
-            <RtcProvider>
-              <FlexRadioProvider>
-                <RuntimeProvider>
-                  <AudioProvider>
-                    <ControlsProvider>
-                      <AppInner />
-                    </ControlsProvider>
-                  </AudioProvider>
-                </RuntimeProvider>
-              </FlexRadioProvider>
-            </RtcProvider>
+            <DebugModeProvider>
+              <RtcProvider>
+                <FlexRadioProvider>
+                  <RuntimeProvider>
+                    <AudioProvider>
+                      <ControlsProvider>
+                        <AppInner />
+                      </ControlsProvider>
+                    </AudioProvider>
+                  </RuntimeProvider>
+                </FlexRadioProvider>
+              </RtcProvider>
+            </DebugModeProvider>
           </Show>
           <ReleaseNotification />
         </PreferencesProvider>

--- a/apps/web/src/components/debug-mode/banner.tsx
+++ b/apps/web/src/components/debug-mode/banner.tsx
@@ -1,0 +1,57 @@
+import { Show, createSignal } from "solid-js";
+import { unwrap } from "solid-js/store";
+import { useDebugMode } from "~/context/debug-mode";
+import useFlexRadio from "~/context/flexradio";
+import { Button } from "~/components/ui/button";
+import { DebugPreviewModal } from "./preview-modal";
+
+export function DebugBanner() {
+  const debug = useDebugMode();
+  if (!debug.enabled) return null;
+
+  const flex = useFlexRadio();
+  const [reportJson, setReportJson] = createSignal<string | null>(null);
+
+  const generate = async () => {
+    const snapshot = JSON.parse(JSON.stringify(unwrap(flex.state)));
+    const firmwareVersion: string | null =
+      snapshot.status?.radio?.version ?? null;
+    const model: string | null = snapshot.status?.radio?.model ?? null;
+
+    flex.disconnect();
+    await Promise.resolve();
+
+    const json = debug.generateReport({
+      state: snapshot,
+      firmwareVersion,
+      model,
+    });
+    setReportJson(json);
+  };
+
+  return (
+    <>
+      <div class="w-full bg-red-700 text-white px-3 py-2 flex items-center justify-between gap-3 z-50">
+        <div>
+          <strong>DEBUG MODE</strong> — TCP traffic, console output, and app
+          state are being recorded for this session. Do not share casually.
+        </div>
+        <div class="flex items-center gap-3 text-sm">
+          <span>{debug.messageCount()} msgs</span>
+          <span>{debug.logCount()} logs</span>
+          <Button onClick={generate} class="bg-white text-red-700">
+            Generate Debug Report
+          </Button>
+        </div>
+      </div>
+      <Show when={reportJson()}>
+        {(json) => (
+          <DebugPreviewModal
+            json={json()}
+            onClose={() => setReportJson(null)}
+          />
+        )}
+      </Show>
+    </>
+  );
+}

--- a/apps/web/src/components/debug-mode/preview-modal.tsx
+++ b/apps/web/src/components/debug-mode/preview-modal.tsx
@@ -26,9 +26,10 @@ export function DebugPreviewModal(props: DebugPreviewModalProps) {
         <div class="p-4 border-b border-zinc-800">
           <div class="font-bold">Debug Report Preview</div>
           <div class="text-sm text-zinc-400 mt-1">
-            Search (Ctrl-F) for your callsign, MAC, IP, or lat/lon. Anything
-            still visible is a sanitizer miss — please tell us instead of
-            attaching.
+            Your callsign, IP addresses, GPS data, etc. have been removed from
+            the report automatically, but you should review the information
+            below and ensure it doesn't contain any information you don't want
+            to share publicly.
           </div>
         </div>
         <pre class="flex-1 overflow-auto p-4 text-xs font-mono whitespace-pre">

--- a/apps/web/src/components/debug-mode/preview-modal.tsx
+++ b/apps/web/src/components/debug-mode/preview-modal.tsx
@@ -1,0 +1,58 @@
+import { createSignal } from "solid-js";
+import { Button } from "~/components/ui/button";
+
+interface DebugPreviewModalProps {
+  json: string;
+  onClose: () => void;
+}
+
+export function DebugPreviewModal(props: DebugPreviewModalProps) {
+  const [acknowledged, setAcknowledged] = createSignal(false);
+
+  const download = () => {
+    const blob = new Blob([props.json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `solidsdr-debug-${Math.floor(Date.now() / 1000)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    props.onClose();
+  };
+
+  return (
+    <div class="fixed inset-0 bg-black/70 z-[100] flex items-center justify-center p-4">
+      <div class="bg-zinc-900 text-zinc-100 rounded-lg max-w-5xl w-full max-h-[90vh] flex flex-col">
+        <div class="p-4 border-b border-zinc-800">
+          <div class="font-bold">Debug Report Preview</div>
+          <div class="text-sm text-zinc-400 mt-1">
+            Search (Ctrl-F) for your callsign, MAC, IP, or lat/lon. Anything
+            still visible is a sanitizer miss — please tell us instead of
+            attaching.
+          </div>
+        </div>
+        <pre class="flex-1 overflow-auto p-4 text-xs font-mono whitespace-pre">
+          {props.json}
+        </pre>
+        <div class="p-4 border-t border-zinc-800 flex items-center justify-between gap-3">
+          <label class="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={acknowledged()}
+              onChange={(e) => setAcknowledged(e.currentTarget.checked)}
+            />
+            I've reviewed this and I'm OK sharing it.
+          </label>
+          <div class="flex gap-2">
+            <Button onClick={props.onClose} variant="ghost">
+              Cancel
+            </Button>
+            <Button onClick={download} disabled={!acknowledged()}>
+              Download
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/context/audio.tsx
+++ b/apps/web/src/context/audio.tsx
@@ -209,7 +209,7 @@ export const AudioProvider: ParentComponent = (props) => {
       if (!state.clientHandle || !preferences.dax.rx[daxChannel]?.enabled)
         return;
       const promise = radio()?.createDaxRxAudioStream({ daxChannel });
-      promise.then((controller) =>
+      promise?.then((controller) =>
         daxRxControllers.set(controller.daxChannel, controller),
       );
       onCleanup(() =>

--- a/apps/web/src/context/debug-mode.tsx
+++ b/apps/web/src/context/debug-mode.tsx
@@ -1,0 +1,87 @@
+import {
+  createContext,
+  createSignal,
+  onCleanup,
+  type ParentComponent,
+  useContext,
+} from "solid-js";
+import {
+  CaptureBuffers,
+  installConsoleCapture,
+  wrapTransport,
+  assembleReport,
+} from "~/lib/debug-mode";
+import type { FlexTransport } from "@repo/flexlib";
+import { APP_VERSION } from "~/lib/version";
+
+function readDebugFlag(): boolean {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get("debug") === "true";
+}
+
+interface DebugModeContextValue {
+  enabled: boolean;
+  messageCount: () => number;
+  logCount: () => number;
+  wrapTransportIfEnabled: (t: FlexTransport) => FlexTransport;
+  generateReport: (input: {
+    state: unknown;
+    firmwareVersion: string | null;
+    model: string | null;
+  }) => string;
+}
+
+const DebugModeContext = createContext<DebugModeContextValue>();
+
+export const DebugModeProvider: ParentComponent = (props) => {
+  const enabled = readDebugFlag();
+  const buffers = new CaptureBuffers();
+  const [messageCount, setMessageCount] = createSignal(0);
+  const [logCount, setLogCount] = createSignal(0);
+
+  if (enabled) {
+    const teardown = installConsoleCapture(buffers);
+    const interval = setInterval(() => {
+      setMessageCount(buffers.messageCount);
+      setLogCount(buffers.logCount);
+    }, 500);
+    onCleanup(() => {
+      clearInterval(interval);
+      teardown();
+    });
+  }
+
+  const value: DebugModeContextValue = {
+    enabled,
+    messageCount,
+    logCount,
+    wrapTransportIfEnabled: (t) => (enabled ? wrapTransport(t, buffers) : t),
+    generateReport: ({ state, firmwareVersion, model }) =>
+      assembleReport({
+        meta: {
+          generatedAt: new Date().toISOString(),
+          solidSdrVersion: APP_VERSION,
+          firmwareVersion,
+          model,
+          captureDurationMs: buffers.captureDurationMs,
+        },
+        state,
+        messages: buffers.messages,
+        logs: buffers.logs,
+      }),
+  };
+
+  return (
+    <DebugModeContext.Provider value={value}>
+      {props.children}
+    </DebugModeContext.Provider>
+  );
+};
+
+export function useDebugMode(): DebugModeContextValue {
+  const ctx = useContext(DebugModeContext);
+  if (!ctx)
+    throw new Error("useDebugMode must be used inside DebugModeProvider");
+  return ctx;
+}

--- a/apps/web/src/context/flexradio.tsx
+++ b/apps/web/src/context/flexradio.tsx
@@ -47,9 +47,10 @@ import type {
   FilterPresetSnapshot,
   DisconnectedReason,
 } from "@repo/flexlib";
-import { createFlexClient } from "@repo/flexlib/bridge";
+import { BridgeTransport } from "@repo/flexlib/bridge";
 import { useRtc } from "./rtc";
 import { usePreferences } from "./preferences";
+import { useDebugMode } from "./debug-mode";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Timeline } from "~/components/ui/timeline";
 import { InfoItem } from "~/components/settings/common";
@@ -236,11 +237,12 @@ export const FlexRadioProvider: ParentComponent = (props) => {
     }
   };
 
+  const debug = useDebugMode();
   const flexClient = createMemo(() => {
     const pc = peerConnection();
-    return pc && rtcState.connectionState === "connected"
-      ? createFlexClient(pc)
-      : null;
+    if (!pc || rtcState.connectionState !== "connected") return null;
+    const transport = debug.wrapTransportIfEnabled(new BridgeTransport(pc));
+    return new FlexClient({ transport });
   });
 
   const updateDiscoveryRadio = (descriptor?: FlexRadioDescriptor) => {

--- a/apps/web/src/lib/debug-mode/assemble.ts
+++ b/apps/web/src/lib/debug-mode/assemble.ts
@@ -1,0 +1,66 @@
+import type { CapturedLog, CapturedMessage } from "./buffers";
+import { extractValueSet, sanitize, type ValueSetEntry } from "./sanitize";
+
+export interface ReportMetaInput {
+  generatedAt: string;
+  solidSdrVersion: string;
+  firmwareVersion: string | null;
+  model: string | null;
+  captureDurationMs: number;
+}
+
+export interface ReportInput {
+  meta: ReportMetaInput;
+  state: unknown;
+  messages: readonly CapturedMessage[];
+  logs: readonly CapturedLog[];
+}
+
+/**
+ * Sanitize object keys and string values using the value set.
+ * Numbers that match PII values are converted to their token strings
+ * so the resulting JSON remains valid.
+ */
+function sanitizeValue(v: unknown, valueSet: ValueSetEntry[]): unknown {
+  if (typeof v === "string") {
+    return sanitize(v, valueSet);
+  }
+  if (typeof v === "number") {
+    const s = String(v);
+    const sanitized = sanitize(s, valueSet);
+    // If the numeric value was replaced, return a string token.
+    return sanitized === s ? v : sanitized;
+  }
+  if (Array.isArray(v)) {
+    return v.map((item) => sanitizeValue(item, valueSet));
+  }
+  if (typeof v === "object" && v !== null) {
+    const obj = v as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(obj)) {
+      const sanitizedKey = sanitize(key, valueSet);
+      result[sanitizedKey] = sanitizeValue(obj[key], valueSet);
+    }
+    return result;
+  }
+  return v;
+}
+
+export function assembleReport(input: ReportInput): string {
+  const valueSet = extractValueSet(input.state);
+
+  const meta = {
+    ...input.meta,
+    messageCount: input.messages.length,
+    logCount: input.logs.length,
+  };
+
+  const raw = {
+    meta,
+    state: sanitizeValue(input.state, valueSet),
+    messages: sanitizeValue(input.messages, valueSet),
+    logs: sanitizeValue(input.logs, valueSet),
+  };
+
+  return JSON.stringify(raw, null, 2);
+}

--- a/apps/web/src/lib/debug-mode/buffers.ts
+++ b/apps/web/src/lib/debug-mode/buffers.ts
@@ -1,0 +1,48 @@
+export type Direction = "in" | "out";
+
+export type LogLevel = "log" | "info" | "warn" | "error" | "debug";
+
+export interface CapturedMessage {
+  ts: number;
+  dir: Direction;
+  line: string;
+}
+
+export interface CapturedLog {
+  ts: number;
+  level: LogLevel;
+  message: string;
+  stack?: string;
+}
+
+export class CaptureBuffers {
+  readonly messages: CapturedMessage[] = [];
+  readonly logs: CapturedLog[] = [];
+  readonly startedAt: number = Date.now();
+
+  recordMessage(dir: Direction, line: string): void {
+    this.messages.push({ ts: this.now(), dir, line });
+  }
+
+  recordLog(level: LogLevel, message: string, stack?: string): void {
+    const entry: CapturedLog = { ts: this.now(), level, message };
+    if (stack !== undefined) entry.stack = stack;
+    this.logs.push(entry);
+  }
+
+  get messageCount(): number {
+    return this.messages.length;
+  }
+
+  get logCount(): number {
+    return this.logs.length;
+  }
+
+  get captureDurationMs(): number {
+    return this.now();
+  }
+
+  private now(): number {
+    return Date.now() - this.startedAt;
+  }
+}

--- a/apps/web/src/lib/debug-mode/capture-transport.ts
+++ b/apps/web/src/lib/debug-mode/capture-transport.ts
@@ -1,0 +1,87 @@
+import type {
+  FlexConnection,
+  FlexConnectionEvents,
+  FlexTransport,
+  Subscription,
+  RadioEndpoint,
+} from "@repo/flexlib";
+import type { CaptureBuffers } from "./buffers";
+
+export function wrapTransport(
+  inner: FlexTransport,
+  buffers: CaptureBuffers,
+): FlexTransport {
+  return {
+    on: (event, handler) => inner.on(event, handler),
+    startDiscovery: () => inner.startDiscovery(),
+    stopDiscovery: () => inner.stopDiscovery(),
+    createConnection: () => wrapConnection(inner.createConnection(), buffers),
+    close: () => inner.close(),
+  };
+}
+
+function wrapConnection(
+  inner: FlexConnection,
+  buffers: CaptureBuffers,
+): FlexConnection {
+  let pending = "";
+  let decoder: TextDecoder | undefined;
+
+  const recordChunk = (data: string | Uint8Array) => {
+    let chunk: string;
+    if (typeof data === "string") {
+      chunk = data;
+    } else {
+      decoder = decoder ?? new TextDecoder();
+      chunk = decoder.decode(data, { stream: true });
+    }
+    pending += chunk;
+    while (true) {
+      const newlineIndex = pending.indexOf("\n");
+      if (newlineIndex === -1) break;
+      const line = pending.slice(0, newlineIndex).replace(/\r$/, "");
+      pending = pending.slice(newlineIndex + 1);
+      if (line.length > 0) buffers.recordMessage("in", line);
+    }
+  };
+
+  return {
+    on<K extends keyof FlexConnectionEvents>(
+      event: K,
+      handler: (payload: FlexConnectionEvents[K]) => void,
+    ): Subscription {
+      if (event === "tcpData") {
+        return inner.on(event, (payload) => {
+          recordChunk(payload as string | Uint8Array);
+          handler(payload);
+        });
+      }
+      return inner.on(event, handler);
+    },
+    once<K extends keyof FlexConnectionEvents>(
+      event: K,
+      handler: (payload: FlexConnectionEvents[K]) => void,
+    ): Subscription {
+      if (event === "tcpData") {
+        return inner.once(event, (payload) => {
+          recordChunk(payload as string | Uint8Array);
+          handler(payload);
+        });
+      }
+      return inner.once(event, handler);
+    },
+    connectTcp: (endpoint: RadioEndpoint) => inner.connectTcp(endpoint),
+    connectUdp: (endpoint: RadioEndpoint) => inner.connectUdp(endpoint),
+    sendTcp: async (data: string) => {
+      const line = data.replace(/\r?\n$/, "");
+      if (line.length > 0) buffers.recordMessage("out", line);
+      return inner.sendTcp(data);
+    },
+    sendUdp: (data: Uint8Array) => inner.sendUdp(data),
+    openUpload: (endpoint: RadioEndpoint, data: AsyncIterable<Uint8Array>) =>
+      inner.openUpload(endpoint, data),
+    prepareDownload: (endpoint: RadioEndpoint) =>
+      inner.prepareDownload(endpoint),
+    close: () => inner.close(),
+  };
+}

--- a/apps/web/src/lib/debug-mode/console-capture.ts
+++ b/apps/web/src/lib/debug-mode/console-capture.ts
@@ -1,0 +1,60 @@
+import type { CaptureBuffers, LogLevel } from "./buffers";
+
+const LEVELS: readonly LogLevel[] = ["log", "info", "warn", "error", "debug"];
+
+export function installConsoleCapture(buffers: CaptureBuffers): () => void {
+  const originals = new Map<LogLevel, (...args: unknown[]) => void>();
+  for (const level of LEVELS) {
+    const original = console[level] as (...args: unknown[]) => void;
+    originals.set(level, original);
+    console[level] = ((...args: unknown[]) => {
+      try {
+        buffers.recordLog(level, formatArgs(args));
+      } catch {
+        // never let capture failures break the host page
+      }
+      original.apply(console, args);
+    }) as typeof console.log;
+  }
+
+  const onError = (event: ErrorEvent) => {
+    const stack = event.error instanceof Error ? event.error.stack : undefined;
+    buffers.recordLog("error", event.message || String(event.error), stack);
+  };
+  const onRejection = (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+    const message =
+      reason instanceof Error ? reason.message : safeStringify(reason);
+    const stack = reason instanceof Error ? reason.stack : undefined;
+    buffers.recordLog("error", `Unhandled rejection: ${message}`, stack);
+  };
+
+  window.addEventListener("error", onError);
+  window.addEventListener("unhandledrejection", onRejection);
+
+  return () => {
+    for (const [level, original] of originals) {
+      console[level] = original as typeof console.log;
+    }
+    window.removeEventListener("error", onError);
+    window.removeEventListener("unhandledrejection", onRejection);
+  };
+}
+
+function formatArgs(args: readonly unknown[]): string {
+  return args.map(formatOne).join(" ");
+}
+
+function formatOne(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return `${value.name}: ${value.message}`;
+  return safeStringify(value);
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/web/src/lib/debug-mode/index.ts
+++ b/apps/web/src/lib/debug-mode/index.ts
@@ -1,0 +1,13 @@
+export { CaptureBuffers } from "./buffers";
+export type {
+  CapturedMessage,
+  CapturedLog,
+  Direction,
+  LogLevel,
+} from "./buffers";
+export { installConsoleCapture } from "./console-capture";
+export { wrapTransport } from "./capture-transport";
+export { assembleReport } from "./assemble";
+export type { ReportInput, ReportMetaInput } from "./assemble";
+export { extractValueSet, sanitize } from "./sanitize";
+export type { ValueSetEntry, Category } from "./sanitize";

--- a/apps/web/src/lib/debug-mode/sanitize.ts
+++ b/apps/web/src/lib/debug-mode/sanitize.ts
@@ -1,0 +1,290 @@
+export type Category =
+  | "MAC"
+  | "SERIAL"
+  | "IP_RADIO"
+  | "IP_CLIENT"
+  | "HOST"
+  | "STATION"
+  | "NICKNAME"
+  | "CALLSIGN"
+  | "GRID"
+  | "LAT"
+  | "LON";
+
+export interface ValueSetEntry {
+  value: string;
+  token: string;
+}
+
+const MIN_VALUE_LENGTH = 4;
+const VALUE_DENYLIST = new Set([
+  "0.0.0.0",
+  "255.255.255.0",
+  "255.255.255.255",
+]);
+
+interface RawCollection {
+  category: Category;
+  values: string[];
+}
+
+export function extractValueSet(state: unknown): ValueSetEntry[] {
+  const collections: RawCollection[] = [
+    { category: "MAC", values: collectMacs(state) },
+    { category: "SERIAL", values: collectSerials(state) },
+    { category: "IP_RADIO", values: collectRadioIps(state) },
+    { category: "IP_CLIENT", values: collectClientIps(state) },
+    { category: "HOST", values: collectHosts(state) },
+    { category: "STATION", values: collectStations(state) },
+    { category: "NICKNAME", values: collectNicknames(state) },
+    { category: "CALLSIGN", values: collectCallsigns(state) },
+    { category: "GRID", values: collectGrids(state) },
+    { category: "LAT", values: collectLatitudes(state) },
+    { category: "LON", values: collectLongitudes(state) },
+  ];
+
+  const entries: ValueSetEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const { category, values } of collections) {
+    let n = 1;
+    for (const value of values) {
+      if (!isKeepable(value)) continue;
+      if (seen.has(value)) continue;
+      seen.add(value);
+      entries.push({ value, token: `<${category}_${n}>` });
+      n++;
+    }
+  }
+
+  entries.sort((a, b) => b.value.length - a.value.length);
+  return entries;
+}
+
+function isKeepable(value: string): boolean {
+  if (value.length < MIN_VALUE_LENGTH) return false;
+  if (VALUE_DENYLIST.has(value)) return false;
+  return true;
+}
+
+export function sanitize(text: string, valueSet: ValueSetEntry[]): string {
+  let out = text;
+  for (const { value, token } of valueSet) {
+    out = replaceAllCaseInsensitive(out, value, token);
+  }
+  return out;
+}
+
+function replaceAllCaseInsensitive(
+  haystack: string,
+  needle: string,
+  replacement: string,
+): string {
+  if (!needle) return haystack;
+  const lowerNeedle = needle.toLowerCase();
+  let result = "";
+  let i = 0;
+  while (i < haystack.length) {
+    const slice = haystack.slice(i, i + needle.length);
+    if (slice.toLowerCase() === lowerNeedle) {
+      result += replacement;
+      i += needle.length;
+    } else {
+      result += haystack[i];
+      i++;
+    }
+  }
+  return result;
+}
+
+// --- per-category collectors ---
+
+type AnyRecord = Record<string, unknown>;
+
+function asObject(v: unknown): AnyRecord | undefined {
+  return typeof v === "object" && v !== null ? (v as AnyRecord) : undefined;
+}
+
+function getPath(root: unknown, path: readonly string[]): unknown {
+  let cur: unknown = root;
+  for (const seg of path) {
+    const obj = asObject(cur);
+    if (!obj) return undefined;
+    cur = obj[seg];
+  }
+  return cur;
+}
+
+function asString(v: unknown): string | undefined {
+  if (typeof v === "string" && v.length > 0) return v;
+  if (typeof v === "number" && Number.isFinite(v)) return String(v);
+  return undefined;
+}
+
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    const s = asString(item);
+    if (s !== undefined) out.push(s);
+  }
+  return out;
+}
+
+function eachRecordValue(v: unknown): AnyRecord[] {
+  const obj = asObject(v);
+  if (!obj) return [];
+  const out: AnyRecord[] = [];
+  for (const k of Object.keys(obj)) {
+    const child = asObject(obj[k]);
+    if (child) out.push(child);
+  }
+  return out;
+}
+
+function collectMacs(state: unknown): string[] {
+  const out: string[] = [];
+  const radio = asString(getPath(state, ["status", "radio", "macAddress"]));
+  if (radio) out.push(radio);
+  const license = asString(getPath(state, ["status", "featureLicense", "radioId"]));
+  if (license) out.push(license);
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    const v = asString(r.radioLicenseId);
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+function collectSerials(state: unknown): string[] {
+  const out: string[] = [];
+  const radio = asString(getPath(state, ["status", "radio", "serial"]));
+  if (radio) out.push(radio);
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    const v = asString(r.serial);
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+function collectRadioIps(state: unknown): string[] {
+  const out: string[] = [];
+  const paths: readonly (readonly string[])[] = [
+    ["status", "radio", "ipAddress"],
+    ["status", "radio", "gateway"],
+    ["status", "radio", "netmask"],
+    ["status", "radio", "wfpIpAddress"],
+    ["connectModal", "selectedRadio"],
+  ];
+  for (const p of paths) {
+    const v = asString(getPath(state, p));
+    if (v) out.push(v);
+  }
+  const discovered = asObject(getPath(state, ["discoveredRadios"]));
+  if (discovered) {
+    for (const key of Object.keys(discovered)) out.push(key);
+    for (const r of eachRecordValue(discovered)) {
+      const host = asString(r.host);
+      if (host) out.push(host);
+    }
+  }
+  return out;
+}
+
+function collectClientIps(state: unknown): string[] {
+  const out: string[] = [];
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    out.push(...asStringArray(r.inUseIps));
+    out.push(...asStringArray(r.guiClientIps));
+    if (Array.isArray(r.guiClients)) {
+      for (const gc of r.guiClients) {
+        const obj = asObject(gc);
+        if (!obj) continue;
+        const ip = asString(obj.ip);
+        if (ip) out.push(ip);
+      }
+    }
+  }
+  for (const r of eachRecordValue(getPath(state, ["status", "audioStream"]))) {
+    const v = asString(r.ip);
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+function collectHosts(state: unknown): string[] {
+  const out: string[] = [];
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    out.push(...asStringArray(r.inUseHosts));
+    out.push(...asStringArray(r.guiClientHosts));
+    if (Array.isArray(r.guiClients)) {
+      for (const gc of r.guiClients) {
+        const obj = asObject(gc);
+        if (!obj) continue;
+        const host = asString(obj.host);
+        if (host) out.push(host);
+      }
+    }
+  }
+  return out;
+}
+
+function collectStations(state: unknown): string[] {
+  const out: string[] = [];
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    out.push(...asStringArray(r.guiClientStations));
+  }
+  for (const r of eachRecordValue(getPath(state, ["status", "guiClient"]))) {
+    const v = asString(r.station);
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+function collectNicknames(state: unknown): string[] {
+  const out: string[] = [];
+  const radio = asString(getPath(state, ["status", "radio", "nickname"]));
+  if (radio) out.push(radio);
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    const v = asString(r.nickname);
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+function collectCallsigns(state: unknown): string[] {
+  const out: string[] = [];
+  const radio = asString(getPath(state, ["status", "radio", "callsign"]));
+  if (radio) out.push(radio);
+  for (const r of eachRecordValue(getPath(state, ["discoveredRadios"]))) {
+    const v = asString(r.callsign);
+    if (v) out.push(v);
+  }
+  for (const r of eachRecordValue(getPath(state, ["status", "memory"]))) {
+    const owner = asString(r.owner);
+    if (owner) out.push(owner);
+    const name = asString(r.name);
+    if (name) out.push(name);
+  }
+  return out;
+}
+
+function collectGrids(state: unknown): string[] {
+  const out: string[] = [];
+  const v = asString(getPath(state, ["status", "radio", "gpsGrid"]));
+  if (v) out.push(v);
+  return out;
+}
+
+function collectLatitudes(state: unknown): string[] {
+  const out: string[] = [];
+  const v = asString(getPath(state, ["status", "radio", "gpsLatitude"]));
+  if (v) out.push(v);
+  return out;
+}
+
+function collectLongitudes(state: unknown): string[] {
+  const out: string[] = [];
+  const v = asString(getPath(state, ["status", "radio", "gpsLongitude"]));
+  if (v) out.push(v);
+  return out;
+}

--- a/packages/flexlib/src/bridge.ts
+++ b/packages/flexlib/src/bridge.ts
@@ -41,4 +41,5 @@ export function createFlexClient(
   });
 }
 
+export { BridgeTransport } from "./flex/bridge-transport.js";
 export type { BridgePeerConnection } from "./flex/bridge-transport.js";


### PR DESCRIPTION
## Debug Reports

It's now possible to load the app in a "debug mode" by appending `?debug=true` to the URL.  Doing so adds a new banner to the top of the app with a Generate Debug Report button:

<img width="846" height="69" alt="image" src="https://github.com/user-attachments/assets/041d9dfe-77ab-46b4-b44d-abe33e74332e" />

When the button is clicked, a model opens to show a preview of the debug report, which can then be downloaded and shared with developers:

<img width="829" height="810" alt="image" src="https://github.com/user-attachments/assets/242e7851-558c-45ec-bb5d-b3d5a2638724" />
