### PR TITLE
Panadapter Performance Optimization

### DIFF
--- a/apps/web/src/components/fps.tsx
+++ b/apps/web/src/components/fps.tsx
@@ -3,6 +3,14 @@ import { createEffect, createSignal, For, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import { Card, CardContent } from "~/components/ui/card";
 import { useRuntime } from "~/context/runtime";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuPortal,
+  ContextMenuTrigger,
+} from "./ui/context-menu";
+import { usePreferences } from "~/context/preferences";
 
 const COLORS = [
   "text-amber-400",
@@ -15,6 +23,7 @@ const COLORS = [
 export function FPSCounter() {
   const [running, setRunning] = createSignal(true);
   const { runtime, setRuntime } = useRuntime();
+  const { setPreferences } = usePreferences();
   const { draggable } = createDraggable();
   let lastTime = performance.now();
   const frameTimes: number[] = [];
@@ -38,23 +47,34 @@ export function FPSCounter() {
 
   return (
     <Portal>
-      <div use:draggable={{ handle: ".handle" }} class="absolute z-50">
-        <Card class="fancy-bg-card! handle cursor-move">
-          <CardContent class="py-2 px-4 select-none">
-            <For each={Object.keys(runtime.fps)}>
-              {(key, i) => (
-                <div
-                  class={`text-lg font-mono whitespace-pre font-bold ${
-                    COLORS[i() % COLORS.length]
-                  }`}
-                >
-                  {key}: {runtime.fps[key]?.toString().padStart(4, " ")}
-                </div>
-              )}
-            </For>
-          </CardContent>
-        </Card>
-      </div>
+      <ContextMenu>
+        <div use:draggable={{ handle: ".handle" }} class="absolute z-50">
+          <ContextMenuTrigger>
+            <Card class="fancy-bg-card! handle cursor-move">
+              <CardContent class="py-2 px-4 select-none">
+                <For each={Object.keys(runtime.fps)}>
+                  {(key, i) => (
+                    <div
+                      class={`text-lg font-mono whitespace-pre font-bold ${
+                        COLORS[i() % COLORS.length]
+                      }`}
+                    >
+                      {key}: {runtime.fps[key]?.toString().padStart(4, " ")}
+                    </div>
+                  )}
+                </For>
+              </CardContent>
+            </Card>
+          </ContextMenuTrigger>
+        </div>
+        <ContextMenuPortal>
+          <ContextMenuContent>
+            <ContextMenuItem onSelect={() => setPreferences("showFps", false)}>
+              Close
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenuPortal>
+      </ContextMenu>
     </Portal>
   );
 }

--- a/apps/web/src/components/panafall/panadapter-protocol.ts
+++ b/apps/web/src/components/panafall/panadapter-protocol.ts
@@ -1,0 +1,32 @@
+// Shared memory layout for the panadapter SAB, used by both the main thread
+// (writer) and the worker (reader). Keeping these constants in one module
+// guarantees both sides agree on the layout.
+//
+// The SAB is laid out as:
+//   [ control: Int32Array(CONTROL_LENGTH) ][ fft data: Uint16Array(DATA_LENGTH) ]
+//
+// The data region is split into NUM_BUFFERS slots of MAX_BINS each. The main
+// thread accumulates each frame into the current write slot, then publishes by
+// storing the slot index + bin count into the control region and bumping the
+// sequence counter (which the worker waits on). Multiple slots let the writer
+// move on to the next frame without overwriting the slot the worker may still
+// be reading.
+
+/** Maximum bins per frame. Comfortably above any realistic panadapter width. */
+export const MAX_BINS = 8192;
+
+/** Number of rotating data slots (writer stays ahead of the reader). */
+export const NUM_BUFFERS = 3;
+
+// Control region — Int32 slots, accessed via Atomics.
+export const CONTROL_LENGTH = 4;
+/** Frame sequence counter; bumped on each completed frame. Worker waits here. */
+export const CONTROL_SEQ = 0;
+/** Slot index (0..NUM_BUFFERS-1) holding the most recently completed frame. */
+export const CONTROL_BUF = 1;
+/** Bin count of the most recently completed frame. */
+export const CONTROL_BINS = 2;
+
+export const CONTROL_BYTES = CONTROL_LENGTH * Int32Array.BYTES_PER_ELEMENT;
+export const DATA_LENGTH = NUM_BUFFERS * MAX_BINS;
+export const SAB_BYTES = CONTROL_BYTES + DATA_LENGTH * Uint16Array.BYTES_PER_ELEMENT;

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -154,7 +154,6 @@ export function Panadapter(props: {
     const getPixelRatio = () =>
       Math.max(Number(devicePixelRatio?.toFixed(2) ?? 1), 1);
     let pixelRatio = getPixelRatio();
-    let transformDirty = true;
 
     const flushFrame = () => {
       rafId = null;
@@ -169,6 +168,27 @@ export function Panadapter(props: {
     };
 
     let lastBinValue = 0;
+
+    // Reusable per-color buckets for the solid fill. Each frame we group bins
+    // by amplitude (= palette index) so every distinct color is drawn as one
+    // batched path of integer device-pixel rects. Pre-allocated and reused
+    // across frames to avoid per-frame allocation. bucketX[colorIndex] holds
+    // the logical bin x-positions for that color; bucketCount its length.
+    let bucketX: Int32Array[] = [];
+    let bucketCount = new Int32Array(0);
+    let bucketColors = 0;
+    let bucketCapacity = 0;
+    const ensureBuckets = (colorCount: number, capacity: number) => {
+      if (bucketColors !== colorCount || bucketCapacity < capacity) {
+        bucketX = Array.from(
+          { length: colorCount },
+          () => new Int32Array(capacity),
+        );
+        bucketCount = new Int32Array(colorCount);
+        bucketColors = colorCount;
+        bucketCapacity = capacity;
+      }
+    };
 
     return (packet: VitaFFTPacket) => {
       const startingBin = packet.startBinIndex;
@@ -189,7 +209,6 @@ export function Panadapter(props: {
       const nextRatio = getPixelRatio();
       if (nextRatio !== pixelRatio) {
         pixelRatio = nextRatio;
-        transformDirty = true;
       }
       const scaleWidth = Math.round(width * pixelRatio);
       const scaleHeight = Math.round(height * pixelRatio);
@@ -200,7 +219,6 @@ export function Panadapter(props: {
         if (offscreen.height !== scaleHeight) {
           offscreen.height = scaleHeight;
         }
-        transformDirty = true;
         skipFrame = frame;
       }
       if (updating()) {
@@ -209,8 +227,25 @@ export function Panadapter(props: {
       if (frame === skipFrame) {
         return;
       }
-      if (transformDirty) {
-        const sharpOffset = pixelRatio === 1 ? 0.5 : 0;
+      // Logical-space transform (for gradient fill / peak line, where smooth
+      // antialiasing is wanted). sharpOffset centers 1px lines at DPR 1.
+      const sharpOffset = pixelRatio === 1 ? 0.5 : 0;
+      const hDev = offscreen.height;
+      const segLeft = Math.round(startingBin * pixelRatio);
+      const segRight = Math.round((startingBin + binsInThisFrame) * pixelRatio);
+
+      // Clear this segment's device-pixel column span (identity transform).
+      offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
+      offscreenCtx.clearRect(
+        startingBin === 0 ? -1 : segLeft,
+        -1,
+        startingBin === 0 ? segRight + 1 : segRight - segLeft,
+        hDev + 1,
+      );
+
+      const { peakStyle, fillStyle } = preferences;
+      if (fillStyle === "gradient") {
+        // Filled spectrum polygon, drawn in logical space (antialiased).
         offscreenCtx.setTransform(
           pixelRatio,
           0,
@@ -219,18 +254,7 @@ export function Panadapter(props: {
           sharpOffset,
           sharpOffset,
         );
-        offscreenCtx.imageSmoothingEnabled = true;
-        transformDirty = false;
-      }
-      offscreenCtx.clearRect(
-        startingBin === 0 ? -1 : startingBin,
-        -1,
-        startingBin === 0 ? binsInThisFrame + 1 : binsInThisFrame,
-        height + 1,
-      );
-      offscreenCtx.lineWidth = 1;
-      const { peakStyle, fillStyle } = preferences;
-      if (fillStyle === "gradient") {
+        offscreenCtx.lineWidth = 1;
         const gradient = fillGradient();
         if (peakStyle === "points") {
           // if the peaks are points, we need to draw the "fill" as individual lines
@@ -263,30 +287,49 @@ export function Panadapter(props: {
           offscreenCtx.fill();
         }
       } else if (fillStyle === "solid") {
-        let currentColor = "";
-        let hasPath = false;
+        // Solid spectrum: one vertical bar per bin, colored by amplitude.
+        // Drawn as integer device-pixel rects so bars stay crisp at any DPR
+        // (incl. fractional), batched one fill() per distinct color via reused
+        // amplitude buckets (no per-frame allocation).
+        ensureBuckets(height, totalBins);
+        bucketCount.fill(0);
         for (let index = 0; index < binsInThisFrame; index++) {
-          const x = startingBin + index;
           const y = bins[index];
+          if (y < 0 || y >= height) continue;
+          bucketX[y][bucketCount[y]++] = startingBin + index;
+        }
+        offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
+        for (let y = 0; y < height; y++) {
+          const count = bucketCount[y];
+          if (!count) continue;
           const color = colors[y];
           if (!color) continue;
-          if (color !== currentColor) {
-            if (hasPath) {
-              offscreenCtx.stroke();
-            }
-            offscreenCtx.strokeStyle = color;
-            offscreenCtx.beginPath();
-            hasPath = true;
-            currentColor = color;
+          offscreenCtx.fillStyle = color;
+          offscreenCtx.beginPath();
+          const yTop = Math.round(y * pixelRatio);
+          const rectH = hDev - yTop;
+          const xs = bucketX[y];
+          for (let j = 0; j < count; j++) {
+            const x = xs[j];
+            const x0 = Math.round(x * pixelRatio);
+            const x1 = Math.round((x + 1) * pixelRatio);
+            offscreenCtx.rect(x0, yTop, x1 - x0, rectH);
           }
-          offscreenCtx.moveTo(x, height);
-          offscreenCtx.lineTo(x, y);
-        }
-        if (hasPath) {
-          offscreenCtx.stroke();
+          offscreenCtx.fill();
         }
       }
       if (peakStyle === "line") {
+        // Peak line: diagonal polyline, logical space (antialiased — sharp
+        // pixel-snapping would make a diagonal look worse, not better).
+        offscreenCtx.setTransform(
+          pixelRatio,
+          0,
+          0,
+          pixelRatio,
+          sharpOffset,
+          sharpOffset,
+        );
+        offscreenCtx.lineWidth = 1;
         offscreenCtx.strokeStyle = "white";
         offscreenCtx.beginPath();
         offscreenCtx.moveTo(startingBin - 1, lastBinValue);
@@ -297,12 +340,19 @@ export function Panadapter(props: {
         }
         offscreenCtx.stroke();
       } else if (peakStyle === "points") {
+        // Peak points: crisp dots aligned to the device-pixel grid. All white,
+        // so batch into one path + single fill() rather than N fillRect calls.
+        offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
         offscreenCtx.fillStyle = "white";
+        offscreenCtx.beginPath();
+        const dot = Math.max(1, Math.round(pixelRatio));
         for (let index = 0; index < binsInThisFrame; index++) {
-          const x = startingBin + index;
           const y = bins[index];
-          offscreenCtx.fillRect(x - 0.5, y - 0.5, 1, 1);
+          const x0 = Math.round((startingBin + index) * pixelRatio);
+          const yTop = Math.round(y * pixelRatio);
+          offscreenCtx.rect(x0, yTop, dot, dot);
         }
+        offscreenCtx.fill();
       }
 
       if (startingBin > 0) {

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -12,7 +12,6 @@ import useFlexRadio, {
 } from "~/context/flexradio";
 import { DetachedSlices, Slice } from "../slice";
 import { debounce } from "@solid-primitives/scheduled";
-import { createElementSize } from "@solid-primitives/resize-observer";
 import { LinearScale } from "../linear-scale";
 import type { LinearScaleTick } from "../linear-scale";
 import { PanadapterGrid } from "./panadapter-grid";
@@ -36,8 +35,6 @@ export function Panadapter(props: {
   const { preferences } = usePreferences();
 
   const [canvasRef, setCanvasRef] = createSignal<HTMLCanvasElement>();
-  const [wrapper, setWrapper] = createSignal<HTMLDivElement>();
-  const wrapperSize = createElementSize(wrapper);
   const [updating, setUpdating] = createSignal(false);
   const [palette, setPalette] = createSignal(new Uint8ClampedArray(0x400));
   const [paletteCss, setPaletteCss] = createSignal<string[]>([]);
@@ -48,8 +45,15 @@ export function Panadapter(props: {
   const frameTimes: number[] = [];
   const { setRuntime } = useRuntime();
 
+  const {
+    slices,
+    setPanadapterControlsRef,
+    setPanadapterWrapper,
+    panadapterWrapperSize,
+  } = usePanafall();
+
   const frequencyTicks = createMemo<FrequencyGridTick[]>(() => {
-    const width = wrapperSize.width;
+    const width = panadapterWrapperSize.width;
     if (!(width && props.pan)) return [];
     const { centerFrequencyMHz, bandwidthMHz } = props.pan;
     return buildFrequencyGrid({
@@ -60,8 +64,6 @@ export function Panadapter(props: {
       minPixelSpacing: 72,
     });
   });
-
-  const { slices, setPanadapterControlsRef } = usePanafall();
 
   createEffect(() => {
     const canvas = canvasRef();
@@ -127,7 +129,7 @@ export function Panadapter(props: {
   }, 250);
 
   createEffect(() => {
-    const { width, height } = wrapperSize;
+    const { width, height } = panadapterWrapperSize;
     if (!width || !height) return;
     resizeCallback(width, height);
   });
@@ -398,10 +400,10 @@ export function Panadapter(props: {
 
   return (
     <div
-      ref={setWrapper}
+      ref={setPanadapterWrapper}
       class="relative shrink size-full flex justify-center overflow-clip select-none bg-radial-[ellipse_at_bottom] from-(--panadapter-background-color) via-(--panadapter-background-color)/70 via-30% to-(--panadapter-background-color)/35 to-85%"
       style={{
-        "--panadapter-available-height": `${wrapperSize.height}px`,
+        "--panadapter-available-height": `${panadapterWrapperSize.height}px`,
         "--panadapter-background-color": txBackgroundColor(),
       }}
     >

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -156,6 +156,7 @@ export function Panadapter(props: {
     const getPixelRatio = () =>
       Math.max(Number(devicePixelRatio?.toFixed(2) ?? 1), 1);
     let pixelRatio = getPixelRatio();
+    let transformDirty = true;
 
     const flushFrame = () => {
       rafId = null;
@@ -170,27 +171,6 @@ export function Panadapter(props: {
     };
 
     let lastBinValue = 0;
-
-    // Reusable per-color buckets for the solid fill. Each frame we group bins
-    // by amplitude (= palette index) so every distinct color is drawn as one
-    // batched path of integer device-pixel rects. Pre-allocated and reused
-    // across frames to avoid per-frame allocation. bucketX[colorIndex] holds
-    // the logical bin x-positions for that color; bucketCount its length.
-    let bucketX: Int32Array[] = [];
-    let bucketCount = new Int32Array(0);
-    let bucketColors = 0;
-    let bucketCapacity = 0;
-    const ensureBuckets = (colorCount: number, capacity: number) => {
-      if (bucketColors !== colorCount || bucketCapacity < capacity) {
-        bucketX = Array.from(
-          { length: colorCount },
-          () => new Int32Array(capacity),
-        );
-        bucketCount = new Int32Array(colorCount);
-        bucketColors = colorCount;
-        bucketCapacity = capacity;
-      }
-    };
 
     return (packet: VitaFFTPacket) => {
       const startingBin = packet.startBinIndex;
@@ -211,6 +191,7 @@ export function Panadapter(props: {
       const nextRatio = getPixelRatio();
       if (nextRatio !== pixelRatio) {
         pixelRatio = nextRatio;
+        transformDirty = true;
       }
       const scaleWidth = Math.round(width * pixelRatio);
       const scaleHeight = Math.round(height * pixelRatio);
@@ -221,6 +202,7 @@ export function Panadapter(props: {
         if (offscreen.height !== scaleHeight) {
           offscreen.height = scaleHeight;
         }
+        transformDirty = true;
         skipFrame = frame;
       }
       if (updating()) {
@@ -229,25 +211,8 @@ export function Panadapter(props: {
       if (frame === skipFrame) {
         return;
       }
-      // Logical-space transform (for gradient fill / peak line, where smooth
-      // antialiasing is wanted). sharpOffset centers 1px lines at DPR 1.
-      const sharpOffset = pixelRatio === 1 ? 0.5 : 0;
-      const hDev = offscreen.height;
-      const segLeft = Math.round(startingBin * pixelRatio);
-      const segRight = Math.round((startingBin + binsInThisFrame) * pixelRatio);
-
-      // Clear this segment's device-pixel column span (identity transform).
-      offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
-      offscreenCtx.clearRect(
-        startingBin === 0 ? -1 : segLeft,
-        -1,
-        startingBin === 0 ? segRight + 1 : segRight - segLeft,
-        hDev + 1,
-      );
-
-      const { peakStyle, fillStyle } = preferences;
-      if (fillStyle === "gradient") {
-        // Filled spectrum polygon, drawn in logical space (antialiased).
+      if (transformDirty) {
+        const sharpOffset = pixelRatio === 1 ? 0.5 : 0;
         offscreenCtx.setTransform(
           pixelRatio,
           0,
@@ -256,7 +221,18 @@ export function Panadapter(props: {
           sharpOffset,
           sharpOffset,
         );
-        offscreenCtx.lineWidth = 1;
+        offscreenCtx.imageSmoothingEnabled = true;
+        transformDirty = false;
+      }
+      offscreenCtx.clearRect(
+        startingBin === 0 ? -1 : startingBin,
+        -1,
+        startingBin === 0 ? binsInThisFrame + 1 : binsInThisFrame,
+        height + 1,
+      );
+      offscreenCtx.lineWidth = 1;
+      const { peakStyle, fillStyle } = preferences;
+      if (fillStyle === "gradient") {
         const gradient = fillGradient();
         if (peakStyle === "points") {
           // if the peaks are points, we need to draw the "fill" as individual lines
@@ -289,49 +265,30 @@ export function Panadapter(props: {
           offscreenCtx.fill();
         }
       } else if (fillStyle === "solid") {
-        // Solid spectrum: one vertical bar per bin, colored by amplitude.
-        // Drawn as integer device-pixel rects so bars stay crisp at any DPR
-        // (incl. fractional), batched one fill() per distinct color via reused
-        // amplitude buckets (no per-frame allocation).
-        ensureBuckets(height, totalBins);
-        bucketCount.fill(0);
+        let currentColor = "";
+        let hasPath = false;
         for (let index = 0; index < binsInThisFrame; index++) {
+          const x = startingBin + index;
           const y = bins[index];
-          if (y < 0 || y >= height) continue;
-          bucketX[y][bucketCount[y]++] = startingBin + index;
-        }
-        offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
-        for (let y = 0; y < height; y++) {
-          const count = bucketCount[y];
-          if (!count) continue;
           const color = colors[y];
           if (!color) continue;
-          offscreenCtx.fillStyle = color;
-          offscreenCtx.beginPath();
-          const yTop = Math.round(y * pixelRatio);
-          const rectH = hDev - yTop;
-          const xs = bucketX[y];
-          for (let j = 0; j < count; j++) {
-            const x = xs[j];
-            const x0 = Math.round(x * pixelRatio);
-            const x1 = Math.round((x + 1) * pixelRatio);
-            offscreenCtx.rect(x0, yTop, x1 - x0, rectH);
+          if (color !== currentColor) {
+            if (hasPath) {
+              offscreenCtx.stroke();
+            }
+            offscreenCtx.strokeStyle = color;
+            offscreenCtx.beginPath();
+            hasPath = true;
+            currentColor = color;
           }
-          offscreenCtx.fill();
+          offscreenCtx.moveTo(x, height);
+          offscreenCtx.lineTo(x, y);
+        }
+        if (hasPath) {
+          offscreenCtx.stroke();
         }
       }
       if (peakStyle === "line") {
-        // Peak line: diagonal polyline, logical space (antialiased — sharp
-        // pixel-snapping would make a diagonal look worse, not better).
-        offscreenCtx.setTransform(
-          pixelRatio,
-          0,
-          0,
-          pixelRatio,
-          sharpOffset,
-          sharpOffset,
-        );
-        offscreenCtx.lineWidth = 1;
         offscreenCtx.strokeStyle = "white";
         offscreenCtx.beginPath();
         offscreenCtx.moveTo(startingBin - 1, lastBinValue);
@@ -342,19 +299,12 @@ export function Panadapter(props: {
         }
         offscreenCtx.stroke();
       } else if (peakStyle === "points") {
-        // Peak points: crisp dots aligned to the device-pixel grid. All white,
-        // so batch into one path + single fill() rather than N fillRect calls.
-        offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
         offscreenCtx.fillStyle = "white";
-        offscreenCtx.beginPath();
-        const dot = Math.max(1, Math.round(pixelRatio));
         for (let index = 0; index < binsInThisFrame; index++) {
+          const x = startingBin + index;
           const y = bins[index];
-          const x0 = Math.round((startingBin + index) * pixelRatio);
-          const yTop = Math.round(y * pixelRatio);
-          offscreenCtx.rect(x0, yTop, dot, dot);
+          offscreenCtx.fillRect(x - 0.5, y - 0.5, 1, 1);
         }
-        offscreenCtx.fill();
       }
 
       if (startingBin > 0) {

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -25,6 +25,7 @@ import { Spots } from "./spots";
 import { Tnf } from "./tnf";
 import { useRuntime } from "~/context/runtime";
 import { DisplayMarkers } from "./display-markers";
+import { deviceScale, pixelDensity } from "~/lib/device-scale";
 
 export function Panadapter(props: {
   pan: PanadapterState;
@@ -36,7 +37,6 @@ export function Panadapter(props: {
 
   const [canvasRef, setCanvasRef] = createSignal<HTMLCanvasElement>();
   const [updating, setUpdating] = createSignal(false);
-  const [palette, setPalette] = createSignal(new Uint8ClampedArray(0x400));
   const [paletteCss, setPaletteCss] = createSignal<string[]>([]);
   const [offscreenCanvasRef, setOffscreenCanvasRef] =
     createSignal<OffscreenCanvas | null>(null);
@@ -90,7 +90,6 @@ export function Panadapter(props: {
     ctx.fillRect(0, 0, offscreen.width, offscreen.height);
     const imageData = ctx.getImageData(0, 0, offscreen.width, offscreen.height);
     const data = imageData.data;
-    setPalette(data);
     const css = new Array<string>(data.length / 4);
     for (let index = 0; index < css.length; index++) {
       const offset = index * 4;
@@ -128,32 +127,11 @@ export function Panadapter(props: {
     setUpdating(false);
   }, 250);
 
-  const [pixelDensity, setPixelDensity] = createSignal(
-    Math.max(window.devicePixelRatio || 1, 1),
-  );
-  createEffect(() => {
-    // A resolution media query only fires when it stops matching its fixed
-    // value, so re-subscribe whenever the density changes. This catches the
-    // window moving to a monitor with a different DPR, where the CSS wrapper
-    // size is unchanged but the device-pixel size isn't.
-    const current = pixelDensity();
-    const query = window.matchMedia(`(resolution: ${current}dppx)`);
-    const onChange = () =>
-      setPixelDensity(Math.max(window.devicePixelRatio || 1, 1));
-    query.addEventListener("change", onChange);
-    onCleanup(() => query.removeEventListener("change", onChange));
-  });
-
   createEffect(() => {
     const { width, height } = panadapterWrapperSize;
-    const density = pixelDensity();
     if (!width || !height) return;
-    // The panadapter occupies a fixed device-pixel region (width * density);
-    // the radio renders it at that region divided by round(density), so the bin
-    // count steps on the DPR rounding boundary and holds constant within each
-    // bucket. We then scale those bins back up to device pixels ourselves while
-    // drawing, so both fills and peak lines rasterize natively at full DPR.
-    const scale = Math.max(1, Math.round(density));
+    const density = pixelDensity();
+    const scale = deviceScale();
     resizeCallback(
       Math.round((width * density) / scale),
       Math.round((height * density) / scale),
@@ -179,18 +157,10 @@ export function Panadapter(props: {
     let skipFrame = 0;
     let frameStartTime = performance.now();
     let rafId: number | null = null;
-    // Integer upscale factor: round(DPR). The offscreen is sized to full device
-    // pixels (bins * scale) and a scale transform draws each bin as a scale-wide
-    // block, so the spectrum rasterizes natively at device resolution and the
-    // canvas blit is 1:1 — no nearest-neighbor upscale to blur or ghost.
-    const getScale = () => Math.max(1, Math.round(devicePixelRatio || 1));
-    let scale = getScale();
     let transformDirty = true;
 
     const flushFrame = () => {
       rafId = null;
-      // The offscreen is already at device resolution, so the canvas matches it
-      // 1:1 and the blit does no scaling.
       if (canvas.width !== offscreen.width) {
         canvas.width = offscreen.width;
       }
@@ -214,15 +184,17 @@ export function Panadapter(props: {
         frameStartTime = performance.now();
         lastBinValue = bins[0];
       }
-      const p = palette();
       const colors = paletteCss();
-      if (!p.length || !colors.length) return;
+      if (!colors.length) return;
       const width = totalBins;
-      const height = p.length / 4;
+      // colors.length === pan.height (the palette is built one column tall at
+      // pan.height), so it doubles as the bin-space height and stays in sync
+      // with the color lookup below.
+      const height = colors.length;
       // Size the offscreen to full device pixels: the stepped bin count times
       // the integer scale. The scale only changes when DPR crosses a rounding
       // boundary, which is also when the radio re-sends a new bin count.
-      scale = getScale();
+      const scale = deviceScale();
       const offscreenWidth = width * scale;
       const offscreenHeight = height * scale;
       if (

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -264,17 +264,15 @@ export function Panadapter(props: {
       if (fillStyle === "gradient") {
         const gradient = fillGradient();
         if (peakStyle === "points") {
-          // if the peaks are points, we need to draw the "fill" as individual lines
-          offscreenCtx.strokeStyle = gradient || "white";
-          offscreenCtx.beginPath();
-          offscreenCtx.moveTo(startingBin, height);
+          // Discrete columns under each point — the same fillRect-per-bin method
+          // as the solid fill, just filled with the gradient. Keeps the columns
+          // pixel-aligned with the point markers drawn on top.
+          offscreenCtx.fillStyle = gradient || "white";
           for (let index = 0; index < binsInThisFrame; index++) {
             const x = startingBin + index;
             const y = bins[index];
-            offscreenCtx.moveTo(x, height);
-            offscreenCtx.lineTo(x, y);
+            offscreenCtx.fillRect(x, y, 1, height - y);
           }
-          offscreenCtx.stroke();
         } else {
           // otherwise we can just outline the shape and fill it
           offscreenCtx.strokeStyle = "transparent";

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -26,6 +26,17 @@ import { Tnf } from "./tnf";
 import { useRuntime } from "~/context/runtime";
 import { DisplayMarkers } from "./display-markers";
 import { deviceScale, pixelDensity } from "~/lib/device-scale";
+import {
+  CONTROL_BINS,
+  CONTROL_BUF,
+  CONTROL_BYTES,
+  CONTROL_LENGTH,
+  CONTROL_SEQ,
+  DATA_LENGTH,
+  MAX_BINS,
+  NUM_BUFFERS,
+  SAB_BYTES,
+} from "./panadapter-protocol";
 
 export function Panadapter(props: {
   pan: PanadapterState;
@@ -36,14 +47,20 @@ export function Panadapter(props: {
   const { preferences } = usePreferences();
 
   const [canvasRef, setCanvasRef] = createSignal<HTMLCanvasElement>();
-  const [updating, setUpdating] = createSignal(false);
   const [paletteCss, setPaletteCss] = createSignal<string[]>([]);
-  const [offscreenCanvasRef, setOffscreenCanvasRef] =
-    createSignal<OffscreenCanvas | null>(null);
   const [levelTicks, setLevelTicks] = createSignal<LinearScaleTick[]>([]);
+  const [worker, setWorker] = createSignal<Worker>();
 
-  const frameTimes: number[] = [];
   const { setRuntime } = useRuntime();
+
+  // Shared buffer the worker draws from. The data event handler writes bins
+  // straight into it and publishes completed frames via the control region;
+  // nothing is copied or messaged per packet.
+  const sab = new SharedArrayBuffer(SAB_BYTES);
+  const control = new Int32Array(sab, 0, CONTROL_LENGTH);
+  const fftData = new Uint16Array(sab, CONTROL_BYTES, DATA_LENGTH);
+  let writeBuf = 0;
+  let frameSeq = 0;
 
   const {
     slices,
@@ -63,12 +80,6 @@ export function Panadapter(props: {
       alignmentOffset: preferences.panadapterOffset,
       minPixelSpacing: 72,
     });
-  });
-
-  createEffect(() => {
-    const canvas = canvasRef();
-    if (!canvas) return;
-    setOffscreenCanvasRef(new OffscreenCanvas(canvas.width, canvas.height));
   });
 
   createEffect(() => {
@@ -102,29 +113,8 @@ export function Panadapter(props: {
     setPaletteCss(css);
   });
 
-  const fillGradient = createMemo(() => {
-    const canvas = offscreenCanvasRef();
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    const { gradients } = preferences.palette;
-    const gradient = ctx.createLinearGradient(0, props.pan.height, 0, 0);
-    if (preferences.gradientStyle === "classic") {
-      gradient.addColorStop(0, "rgba(255, 255, 255, 0.2)");
-      gradient.addColorStop(1, "rgba(255, 255, 255, 1)");
-    } else {
-      const { stops } = gradients[props.waterfall.gradientIndex];
-      stops.forEach(({ offset, color }) => {
-        gradient.addColorStop(offset, color);
-      });
-    }
-    return gradient;
-  });
-
   const resizeCallback = debounce(async (width: number, height: number) => {
-    setUpdating(true);
     await props.controller.setSize({ width, height });
-    setUpdating(false);
   }, 250);
 
   createEffect(() => {
@@ -138,194 +128,88 @@ export function Panadapter(props: {
     );
   });
 
-  const onPanadapter = createMemo(() => {
+  // Hand the canvas to a worker that owns all rasterization. transferControl-
+  // ToOffscreen is one-shot per element, so this is keyed to the canvas ref;
+  // if the canvas ever remounts, the old worker is torn down and a new one
+  // takes over the new canvas.
+  createEffect(() => {
     const canvas = canvasRef();
     if (!canvas) return;
-    const ctx = canvas.getContext("2d", {
-      colorSpace: "display-p3",
-    });
-    if (!ctx) return;
-    const offscreen = offscreenCanvasRef();
-    if (!offscreen) return;
-    const offscreenCtx = offscreen.getContext("2d", {
-      colorSpace: "display-p3",
-    });
-    if (!offscreenCtx) return;
-    ctx.imageSmoothingEnabled = false;
-    offscreenCtx.imageSmoothingEnabled = false;
-
-    let skipFrame = 0;
-    let frameStartTime = performance.now();
-    let rafId: number | null = null;
-    let transformDirty = true;
-
-    const flushFrame = () => {
-      rafId = null;
-      if (canvas.width !== offscreen.width) {
-        canvas.width = offscreen.width;
-      }
-      if (canvas.height !== offscreen.height) {
-        canvas.height = offscreen.height;
-      }
-      ctx.clearRect(-1, -1, canvas.width + 1, canvas.height + 1);
-      ctx.drawImage(offscreen, 0, 0, canvas.width, canvas.height);
-    };
-
-    let lastBinValue = 0;
-
-    return (packet: VitaFFTPacket) => {
-      const startingBin = packet.startBinIndex;
-      const binsInThisFrame = packet.numBins;
-      const totalBins = packet.totalBinsInFrame;
-      const frame = packet.frameIndex;
-      const bins = packet.payload;
-      if (binsInThisFrame === 0) return;
-      if (startingBin === 0) {
-        frameStartTime = performance.now();
-        lastBinValue = bins[0];
-      }
-      const colors = paletteCss();
-      if (!colors.length) return;
-      const width = totalBins;
-      // colors.length === pan.height (the palette is built one column tall at
-      // pan.height), so it doubles as the bin-space height and stays in sync
-      // with the color lookup below.
-      const height = colors.length;
-      // Size the offscreen to full device pixels: the stepped bin count times
-      // the integer scale. The scale only changes when DPR crosses a rounding
-      // boundary, which is also when the radio re-sends a new bin count.
-      const scale = deviceScale();
-      const offscreenWidth = width * scale;
-      const offscreenHeight = height * scale;
-      if (
-        offscreen.width !== offscreenWidth ||
-        offscreen.height !== offscreenHeight
-      ) {
-        if (offscreen.width !== offscreenWidth) {
-          offscreen.width = offscreenWidth;
-        }
-        if (offscreen.height !== offscreenHeight) {
-          offscreen.height = offscreenHeight;
-        }
-        transformDirty = true;
-        skipFrame = frame;
-      }
-      if (updating()) {
-        skipFrame = frame;
-      }
-      if (frame === skipFrame) {
-        return;
-      }
-      if (transformDirty) {
-        // Scale bin coordinates up to device pixels. Bin values are integers
-        // (Uint16) and scale is an integer, so every fillRect lands on whole
-        // device pixels — crisp with no offset needed — while strokes (the peak
-        // line) anti-alias smoothly at full device resolution.
-        offscreenCtx.setTransform(scale, 0, 0, scale, 0, 0);
-        offscreenCtx.imageSmoothingEnabled = false;
-        transformDirty = false;
-      }
-      offscreenCtx.clearRect(
-        startingBin === 0 ? -1 : startingBin,
-        -1,
-        startingBin === 0 ? binsInThisFrame + 1 : binsInThisFrame,
-        height + 1,
-      );
-      offscreenCtx.lineWidth = 1;
-      const { peakStyle, fillStyle } = preferences;
-      if (fillStyle === "gradient") {
-        const gradient = fillGradient();
-        if (peakStyle === "points") {
-          // Discrete columns under each point — the same fillRect-per-bin method
-          // as the solid fill, just filled with the gradient. Keeps the columns
-          // pixel-aligned with the point markers drawn on top.
-          offscreenCtx.fillStyle = gradient || "white";
-          for (let index = 0; index < binsInThisFrame; index++) {
-            const x = startingBin + index;
-            const y = bins[index];
-            offscreenCtx.fillRect(x, y, 1, height - y);
-          }
-        } else {
-          // otherwise we can just outline the shape and fill it
-          offscreenCtx.strokeStyle = "transparent";
-          offscreenCtx.lineWidth = 0;
-          offscreenCtx.fillStyle = gradient || "white";
-          offscreenCtx.beginPath();
-          offscreenCtx.moveTo(startingBin - 1, height);
-          offscreenCtx.lineTo(startingBin - 1, lastBinValue);
-          for (let index = 0; index < binsInThisFrame; index++) {
-            const x = startingBin + index;
-            const y = bins[index];
-            offscreenCtx.lineTo(x, y);
-          }
-          offscreenCtx.lineTo(startingBin + binsInThisFrame - 1, height);
-          offscreenCtx.lineTo(startingBin + binsInThisFrame - 1, height);
-          offscreenCtx.closePath();
-          offscreenCtx.fill();
-        }
-      } else if (fillStyle === "solid") {
-        // One scale-wide fillRect per bin (bar from its peak down to the floor)
-        // rather than scale separate 1px lines. Same draw-call count as the old
-        // stroked version; the rasterizer fills the wider rect in one go.
-        let currentColor = "";
-        for (let index = 0; index < binsInThisFrame; index++) {
-          const x = startingBin + index;
-          const y = bins[index];
-          const color = colors[y];
-          if (!color) continue;
-          if (color !== currentColor) {
-            offscreenCtx.fillStyle = color;
-            currentColor = color;
-          }
-          offscreenCtx.fillRect(x, y, 1, height - y);
-        }
-      }
-      if (peakStyle === "line") {
-        offscreenCtx.strokeStyle = "white";
-        offscreenCtx.beginPath();
-        offscreenCtx.moveTo(startingBin - 1, lastBinValue);
-        for (let index = 0; index < binsInThisFrame; index++) {
-          const x = startingBin + index;
-          const y = bins[index];
-          offscreenCtx.lineTo(x, y);
-        }
-        offscreenCtx.stroke();
-      } else if (peakStyle === "points") {
-        // Each point is one scale x scale block at integer device coords (bin
-        // and amplitude are both integers, scale is integer). No drawImage
-        // upscale means there's nothing left to ghost, in any browser.
-        offscreenCtx.fillStyle = "white";
-        for (let index = 0; index < binsInThisFrame; index++) {
-          const x = startingBin + index;
-          const y = bins[index];
-          offscreenCtx.fillRect(x, y, 1, 1);
-        }
-      }
-
-      if (startingBin > 0) {
-        lastBinValue = bins[binsInThisFrame - 1];
-      }
-
-      if (startingBin + binsInThisFrame >= totalBins) {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
-        }
-        rafId = requestAnimationFrame(flushFrame);
-        if (preferences.showFps) {
-          frameTimes.push(performance.now() - frameStartTime);
-          if (frameTimes.length > 10) frameTimes.shift();
-          const avgFrameTime =
-            frameTimes.reduce((a, b) => a + b, 0) / frameTimes.length;
-          setRuntime("fps", "P", Math.round(1000 / avgFrameTime));
-        }
+    const w = new Worker(
+      new URL("./panadapter.worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    const offscreen = canvas.transferControlToOffscreen();
+    w.postMessage({ type: "init", canvas: offscreen, sab }, [offscreen]);
+    w.onmessage = (event: MessageEvent) => {
+      if (event.data?.type === "fps") {
+        setRuntime("fps", "P", event.data.value);
       }
     };
+    setWorker(w);
+    onCleanup(() => {
+      w.terminate();
+      setWorker(undefined);
+    });
   });
 
+  // Push rendering config to the worker whenever any input changes. These all
+  // change rarely (palette edits, preference toggles, resize, DPR), so
+  // re-posting the whole config on any change is cheap. The worker sizes its
+  // backing store from the expected pan dimensions × scale and derives the
+  // per-frame draw scale from the actual bin count it receives.
   createEffect(() => {
-    const handler = onPanadapter();
-    if (!handler) return;
-    const subscription = props.controller.on("data", handler);
+    const w = worker();
+    if (!w) return;
+    const { gradients } = preferences.palette;
+    // Unwrap reactive store proxies to plain data — structuredClone (used by
+    // postMessage) can't serialize Solid store proxies.
+    const stops = (gradients[props.waterfall.gradientIndex]?.stops ?? []).map(
+      ({ offset, color }) => ({ offset, color }),
+    );
+    w.postMessage({
+      type: "config",
+      config: {
+        width: props.pan.width,
+        height: props.pan.height,
+        scale: deviceScale(),
+        paletteCss: [...paletteCss()],
+        fillStyle: preferences.fillStyle,
+        peakStyle: preferences.peakStyle,
+        gradientStyle: preferences.gradientStyle,
+        gradientStops: stops,
+        showFps: preferences.showFps,
+      },
+    });
+  });
+
+  // Accumulate FFT packets directly into the shared buffer. On the main thread
+  // this is just a typed-array copy into shared memory per packet — no
+  // allocation, no postMessage. When a frame completes we publish the slot and
+  // bin count, then bump the sequence counter (and notify) so the worker draws
+  // it. Frames rotate through NUM_BUFFERS slots so the writer never overwrites
+  // the slot the worker is reading.
+  createEffect(() => {
+    const w = worker();
+    if (!w) return;
+    const subscription = props.controller.on("data", (packet: VitaFFTPacket) => {
+      const numBins = packet.numBins;
+      if (numBins === 0) return;
+      const startBin = packet.startBinIndex;
+      const totalBins = packet.totalBinsInFrame;
+      const end = startBin + numBins;
+      if (end > MAX_BINS) return;
+
+      fftData.set(packet.payload.subarray(0, numBins), writeBuf * MAX_BINS + startBin);
+
+      if (end >= totalBins) {
+        Atomics.store(control, CONTROL_BUF, writeBuf);
+        Atomics.store(control, CONTROL_BINS, totalBins);
+        Atomics.store(control, CONTROL_SEQ, ++frameSeq);
+        Atomics.notify(control, CONTROL_SEQ);
+        writeBuf = (writeBuf + 1) % NUM_BUFFERS;
+      }
+    });
     if (!subscription) return;
     onCleanup(subscription.unsubscribe);
   });

--- a/apps/web/src/components/panafall/panadapter.tsx
+++ b/apps/web/src/components/panafall/panadapter.tsx
@@ -128,10 +128,36 @@ export function Panadapter(props: {
     setUpdating(false);
   }, 250);
 
+  const [pixelDensity, setPixelDensity] = createSignal(
+    Math.max(window.devicePixelRatio || 1, 1),
+  );
+  createEffect(() => {
+    // A resolution media query only fires when it stops matching its fixed
+    // value, so re-subscribe whenever the density changes. This catches the
+    // window moving to a monitor with a different DPR, where the CSS wrapper
+    // size is unchanged but the device-pixel size isn't.
+    const current = pixelDensity();
+    const query = window.matchMedia(`(resolution: ${current}dppx)`);
+    const onChange = () =>
+      setPixelDensity(Math.max(window.devicePixelRatio || 1, 1));
+    query.addEventListener("change", onChange);
+    onCleanup(() => query.removeEventListener("change", onChange));
+  });
+
   createEffect(() => {
     const { width, height } = panadapterWrapperSize;
+    const density = pixelDensity();
     if (!width || !height) return;
-    resizeCallback(width, height);
+    // The panadapter occupies a fixed device-pixel region (width * density);
+    // the radio renders it at that region divided by round(density), so the bin
+    // count steps on the DPR rounding boundary and holds constant within each
+    // bucket. We then scale those bins back up to device pixels ourselves while
+    // drawing, so both fills and peak lines rasterize natively at full DPR.
+    const scale = Math.max(1, Math.round(density));
+    resizeCallback(
+      Math.round((width * density) / scale),
+      Math.round((height * density) / scale),
+    );
   });
 
   const onPanadapter = createMemo(() => {
@@ -153,13 +179,18 @@ export function Panadapter(props: {
     let skipFrame = 0;
     let frameStartTime = performance.now();
     let rafId: number | null = null;
-    const getPixelRatio = () =>
-      Math.max(Number(devicePixelRatio?.toFixed(2) ?? 1), 1);
-    let pixelRatio = getPixelRatio();
+    // Integer upscale factor: round(DPR). The offscreen is sized to full device
+    // pixels (bins * scale) and a scale transform draws each bin as a scale-wide
+    // block, so the spectrum rasterizes natively at device resolution and the
+    // canvas blit is 1:1 — no nearest-neighbor upscale to blur or ghost.
+    const getScale = () => Math.max(1, Math.round(devicePixelRatio || 1));
+    let scale = getScale();
     let transformDirty = true;
 
     const flushFrame = () => {
       rafId = null;
+      // The offscreen is already at device resolution, so the canvas matches it
+      // 1:1 and the blit does no scaling.
       if (canvas.width !== offscreen.width) {
         canvas.width = offscreen.width;
       }
@@ -188,19 +219,21 @@ export function Panadapter(props: {
       if (!p.length || !colors.length) return;
       const width = totalBins;
       const height = p.length / 4;
-      const nextRatio = getPixelRatio();
-      if (nextRatio !== pixelRatio) {
-        pixelRatio = nextRatio;
-        transformDirty = true;
-      }
-      const scaleWidth = Math.round(width * pixelRatio);
-      const scaleHeight = Math.round(height * pixelRatio);
-      if (offscreen.width !== scaleWidth || offscreen.height !== scaleHeight) {
-        if (offscreen.width !== scaleWidth) {
-          offscreen.width = scaleWidth;
+      // Size the offscreen to full device pixels: the stepped bin count times
+      // the integer scale. The scale only changes when DPR crosses a rounding
+      // boundary, which is also when the radio re-sends a new bin count.
+      scale = getScale();
+      const offscreenWidth = width * scale;
+      const offscreenHeight = height * scale;
+      if (
+        offscreen.width !== offscreenWidth ||
+        offscreen.height !== offscreenHeight
+      ) {
+        if (offscreen.width !== offscreenWidth) {
+          offscreen.width = offscreenWidth;
         }
-        if (offscreen.height !== scaleHeight) {
-          offscreen.height = scaleHeight;
+        if (offscreen.height !== offscreenHeight) {
+          offscreen.height = offscreenHeight;
         }
         transformDirty = true;
         skipFrame = frame;
@@ -212,16 +245,12 @@ export function Panadapter(props: {
         return;
       }
       if (transformDirty) {
-        const sharpOffset = pixelRatio === 1 ? 0.5 : 0;
-        offscreenCtx.setTransform(
-          pixelRatio,
-          0,
-          0,
-          pixelRatio,
-          sharpOffset,
-          sharpOffset,
-        );
-        offscreenCtx.imageSmoothingEnabled = true;
+        // Scale bin coordinates up to device pixels. Bin values are integers
+        // (Uint16) and scale is an integer, so every fillRect lands on whole
+        // device pixels — crisp with no offset needed — while strokes (the peak
+        // line) anti-alias smoothly at full device resolution.
+        offscreenCtx.setTransform(scale, 0, 0, scale, 0, 0);
+        offscreenCtx.imageSmoothingEnabled = false;
         transformDirty = false;
       }
       offscreenCtx.clearRect(
@@ -265,27 +294,20 @@ export function Panadapter(props: {
           offscreenCtx.fill();
         }
       } else if (fillStyle === "solid") {
+        // One scale-wide fillRect per bin (bar from its peak down to the floor)
+        // rather than scale separate 1px lines. Same draw-call count as the old
+        // stroked version; the rasterizer fills the wider rect in one go.
         let currentColor = "";
-        let hasPath = false;
         for (let index = 0; index < binsInThisFrame; index++) {
           const x = startingBin + index;
           const y = bins[index];
           const color = colors[y];
           if (!color) continue;
           if (color !== currentColor) {
-            if (hasPath) {
-              offscreenCtx.stroke();
-            }
-            offscreenCtx.strokeStyle = color;
-            offscreenCtx.beginPath();
-            hasPath = true;
+            offscreenCtx.fillStyle = color;
             currentColor = color;
           }
-          offscreenCtx.moveTo(x, height);
-          offscreenCtx.lineTo(x, y);
-        }
-        if (hasPath) {
-          offscreenCtx.stroke();
+          offscreenCtx.fillRect(x, y, 1, height - y);
         }
       }
       if (peakStyle === "line") {
@@ -299,11 +321,14 @@ export function Panadapter(props: {
         }
         offscreenCtx.stroke();
       } else if (peakStyle === "points") {
+        // Each point is one scale x scale block at integer device coords (bin
+        // and amplitude are both integers, scale is integer). No drawImage
+        // upscale means there's nothing left to ghost, in any browser.
         offscreenCtx.fillStyle = "white";
         for (let index = 0; index < binsInThisFrame; index++) {
           const x = startingBin + index;
           const y = bins[index];
-          offscreenCtx.fillRect(x - 0.5, y - 0.5, 1, 1);
+          offscreenCtx.fillRect(x, y, 1, 1);
         }
       }
 

--- a/apps/web/src/components/panafall/panadapter.worker.ts
+++ b/apps/web/src/components/panafall/panadapter.worker.ts
@@ -1,0 +1,237 @@
+/// <reference lib="webworker" />
+
+import {
+  CONTROL_BINS,
+  CONTROL_BUF,
+  CONTROL_BYTES,
+  CONTROL_LENGTH,
+  CONTROL_SEQ,
+  DATA_LENGTH,
+  MAX_BINS,
+} from "./panadapter-protocol";
+
+// Panadapter rendering worker. Owns the canvas transferred from the main
+// thread and does all FFT rasterization off the main thread. The main thread
+// writes bin data straight into a shared buffer and bumps a sequence counter;
+// this worker waits on that counter (Atomics.waitAsync, so its event loop stays
+// free for config messages), then draws the most recently completed frame from
+// shared memory. No per-packet messaging or copying crosses the thread boundary.
+//
+// Sizing: the backing store is set from the *expected* panadapter dimensions
+// (pan.width/height) times the integer device scale, so it stays stable across
+// the radio's lag between requesting a resize and actually applying it. The
+// horizontal draw scale is then derived per frame from the *actual* data
+// (canvas.width / totalBins). In steady state that ratio equals the device
+// scale (integer → bins land on whole device pixels, crisp); during the radio's
+// catch-up window it goes fractional, so stale-size frames draw a touch blurry
+// across the full canvas instead of leaving uncovered regions that flash.
+
+const workerScope = self as unknown as DedicatedWorkerGlobalScope;
+
+type Stop = { offset: number; color: string };
+
+interface Config {
+  /** Expected bin count (pan.width). */
+  width: number;
+  /** Bin-space height (pan.height); also the palette lookup length. */
+  height: number;
+  /** Integer device scale (rounded devicePixelRatio). */
+  scale: number;
+  /** Per-amplitude colour lookup, length === height. */
+  paletteCss: string[];
+  fillStyle: "gradient" | "solid";
+  peakStyle: "line" | "points";
+  gradientStyle: string;
+  gradientStops: Stop[];
+  showFps: boolean;
+}
+
+let canvas: OffscreenCanvas | null = null;
+let ctx: OffscreenCanvasRenderingContext2D | null = null;
+let config: Config | null = null;
+let fillGradient: CanvasGradient | null = null;
+
+let control: Int32Array | null = null;
+let fftData: Uint16Array | null = null;
+let lastSeq = 0;
+
+// Draw-capacity measurement: accumulate time spent in drawFrame and report
+// 1000 / average-draw-time once a second.
+let drawAccumMs = 0;
+let drawCount = 0;
+let lastReport = performance.now();
+
+function applyConfig(next: Config): void {
+  config = next;
+  if (!canvas || !ctx) return;
+  const backingWidth = next.width * next.scale;
+  const backingHeight = next.height * next.scale;
+  if (canvas.width !== backingWidth) canvas.width = backingWidth;
+  if (canvas.height !== backingHeight) canvas.height = backingHeight;
+  ctx.imageSmoothingEnabled = false;
+  rebuildGradient();
+}
+
+// Gradients can't cross the worker boundary, so rebuild from the stops. Built
+// in bin-space coordinates (0..height) and mapped to device pixels by the
+// transform set in drawFrame.
+function rebuildGradient(): void {
+  if (!ctx || !config) return;
+  const gradient = ctx.createLinearGradient(0, config.height, 0, 0);
+  if (config.gradientStyle === "classic") {
+    gradient.addColorStop(0, "rgba(255, 255, 255, 0.2)");
+    gradient.addColorStop(1, "rgba(255, 255, 255, 1)");
+  } else {
+    for (const { offset, color } of config.gradientStops) {
+      gradient.addColorStop(offset, color);
+    }
+  }
+  fillGradient = gradient;
+}
+
+function drawFrame(bins: Uint16Array, totalBins: number): void {
+  if (!canvas || !ctx || !config) return;
+  const w = canvas.width;
+  const h = canvas.height;
+  if (!w || !h || totalBins <= 0) return;
+
+  const binHeight = config.height;
+  const scaleX = w / totalBins;
+  const scaleY = h / binHeight;
+  const colors = config.paletteCss;
+
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+  ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  ctx.lineWidth = 1;
+
+  const { peakStyle, fillStyle } = config;
+
+  if (fillStyle === "gradient") {
+    const gradient = fillGradient ?? "white";
+    if (peakStyle === "points") {
+      // Discrete columns under each point, gradient-filled — keeps the columns
+      // pixel-aligned with the point markers drawn on top.
+      ctx.fillStyle = gradient;
+      for (let i = 0; i < totalBins; i++) {
+        const y = bins[i];
+        ctx.fillRect(i, y, 1, binHeight - y);
+      }
+    } else {
+      // Outline the trace and fill it in one path.
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.moveTo(0, binHeight);
+      ctx.lineTo(0, bins[0]);
+      for (let i = 0; i < totalBins; i++) {
+        ctx.lineTo(i, bins[i]);
+      }
+      ctx.lineTo(totalBins - 1, binHeight);
+      ctx.closePath();
+      ctx.fill();
+    }
+  } else if (fillStyle === "solid") {
+    // One scale-wide fillRect per bin (bar from its peak down to the floor).
+    let currentColor = "";
+    for (let i = 0; i < totalBins; i++) {
+      const y = bins[i];
+      const color = colors[y];
+      if (!color) continue;
+      if (color !== currentColor) {
+        ctx.fillStyle = color;
+        currentColor = color;
+      }
+      ctx.fillRect(i, y, 1, binHeight - y);
+    }
+  }
+
+  if (peakStyle === "line") {
+    ctx.strokeStyle = "white";
+    ctx.beginPath();
+    ctx.moveTo(0, bins[0]);
+    for (let i = 0; i < totalBins; i++) {
+      ctx.lineTo(i, bins[i]);
+    }
+    ctx.stroke();
+  } else if (peakStyle === "points") {
+    ctx.fillStyle = "white";
+    for (let i = 0; i < totalBins; i++) {
+      ctx.fillRect(i, bins[i], 1, 1);
+    }
+  }
+}
+
+// Draw the latest completed frame, if the sequence counter advanced. Reading
+// the latest slot means that if the writer published several frames while we
+// were busy, we naturally coalesce to the newest one and skip the stale ones.
+function handleWake(): void {
+  if (!control || !fftData) return;
+  const seq = Atomics.load(control, CONTROL_SEQ);
+  if (seq !== lastSeq) {
+    lastSeq = seq;
+    const buf = Atomics.load(control, CONTROL_BUF);
+    const totalBins = Atomics.load(control, CONTROL_BINS);
+    const base = buf * MAX_BINS;
+    const t0 = performance.now();
+    drawFrame(fftData.subarray(base, base + totalBins), totalBins);
+    drawAccumMs += performance.now() - t0;
+    drawCount++;
+  }
+  reportCapacity();
+  waitForFrame();
+}
+
+// Report draw *capacity* — how many times per second drawFrame could run at its
+// current per-call cost (1000 / average draw time). This is a headroom gauge,
+// independent of the actual frame arrival rate: it shows how far we can exceed
+// the display refresh and how expensive each panadapter style is. Measured in
+// the worker so it reflects real raster cost, free of main-thread jitter.
+function reportCapacity(): void {
+  const now = performance.now();
+  if (now - lastReport < 1000) return;
+  if (drawCount > 0 && config?.showFps) {
+    const avgMs = drawAccumMs / drawCount;
+    workerScope.postMessage({ type: "fps", value: Math.round(1000 / avgMs) });
+  }
+  drawAccumMs = 0;
+  drawCount = 0;
+  lastReport = now;
+}
+
+function waitForFrame(): void {
+  if (!control) return;
+  const result = Atomics.waitAsync(control, CONTROL_SEQ, lastSeq);
+  if (result.async) {
+    result.value.then(handleWake);
+  } else {
+    // Counter already moved past lastSeq — draw immediately and re-arm.
+    handleWake();
+  }
+}
+
+type IncomingMessage =
+  | { type: "init"; canvas: OffscreenCanvas; sab: SharedArrayBuffer }
+  | { type: "config"; config: Config };
+
+workerScope.onmessage = (event: MessageEvent<IncomingMessage>) => {
+  const msg = event.data;
+  switch (msg.type) {
+    case "init": {
+      canvas = msg.canvas;
+      ctx = canvas.getContext("2d", { colorSpace: "display-p3" });
+      control = new Int32Array(msg.sab, 0, CONTROL_LENGTH);
+      fftData = new Uint16Array(msg.sab, CONTROL_BYTES, DATA_LENGTH);
+      // Start from whatever has already been published so we don't replay old
+      // frames, then arm the wait loop.
+      lastSeq = Atomics.load(control, CONTROL_SEQ);
+      if (config) applyConfig(config);
+      waitForFrame();
+      break;
+    }
+    case "config": {
+      applyConfig(msg.config);
+      break;
+    }
+  }
+};

--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -24,7 +24,12 @@ import MaterialSymbolsAddCommentOutlineRounded from "~icons/material-symbols/add
 import MdiFilterPlus from "~icons/mdi/filter-plus";
 import { Button } from "../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-import { cn, frequencyToLabel, roundToDecimals } from "~/lib/utils";
+import {
+  cn,
+  frequencyToLabel,
+  roundToDecimals,
+  roundToDevicePixels,
+} from "~/lib/utils";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -330,7 +335,6 @@ export function Panafall(props: { index: number }) {
           "--panafall-top": `${panafallBounds.top}px`,
           "--panafall-right": `${panafallBounds.right}px`,
           "--panafall-bottom": `${panafallBounds.bottom}px`,
-
           "--drag-offset": `${dragState.offset}px`,
         }}
       >
@@ -351,10 +355,29 @@ export function Panafall(props: { index: number }) {
                   initialSizes={[0.25, 0.75]}
                   onSizesChange={(sizes) => {
                     if (sizes?.length !== 2) return;
-                    setPreferences("panadapterSizes", props.index, sizes);
+                    const targetHeight = roundToDevicePixels(
+                      sizes[0] * panafallBounds.height,
+                    );
+                    const panHeight = roundToDecimals(
+                      targetHeight / panafallBounds.height,
+                      6,
+                    );
+                    if (
+                      isNaN(panHeight) ||
+                      panHeight === preferences.panadapterSizes[props.index][0]
+                    ) {
+                      return;
+                    }
+                    setPreferences("panadapterSizes", props.index, [
+                      panHeight,
+                      1 - panHeight,
+                    ]);
                   }}
                 >
-                  <ResizablePanel class="overflow-clip select-none">
+                  <ResizablePanel
+                    class="overflow-clip select-none"
+                    minSize="16px"
+                  >
                     <Panadapter
                       pan={pan()}
                       waterfall={waterfall()}

--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -133,6 +133,7 @@ export function Panafall(props: { index: number }) {
     xToFreq,
     setPanafallControlsRef,
     panafallBounds,
+    panadapterWrapperSize,
     setPanafallPortalRef,
   } = usePanafall();
 
@@ -183,7 +184,8 @@ export function Panafall(props: { index: number }) {
     const boundsWidth = panafallBounds.width;
     const boundsLeft = panafallBounds.left;
 
-    const fullWidth = pan.width;
+    const fullWidth = panadapterWrapperSize.width;
+    if (!fullWidth) return;
     const currentCenter = pan.centerFrequencyMHz;
     const currentBandwidth = pan.bandwidthMHz;
 
@@ -204,7 +206,8 @@ export function Panafall(props: { index: number }) {
     const boundsWidth = panafallBounds.width;
     const boundsLeft = panafallBounds.left;
 
-    const fullWidth = pan.width;
+    const fullWidth = panadapterWrapperSize.width;
+    if (!fullWidth) return;
     const currentCenter = pan.centerFrequencyMHz;
     const currentBandwidth = pan.bandwidthMHz;
     const mhzPerPixel = currentBandwidth / fullWidth;

--- a/apps/web/src/components/slice.tsx
+++ b/apps/web/src/components/slice.tsx
@@ -1705,8 +1705,9 @@ export function Slice(props: { slice: SliceState; pan: PanadapterState }) {
       );
       setOffset(
         roundToDevicePixels(
-          freqToX((diversityParent() ?? props.slice).frequencyMHz),
-        ) + preferences.panadapterOffset,
+          freqToX((diversityParent() ?? props.slice).frequencyMHz) +
+            preferences.panadapterOffset,
+        ),
       );
     });
   });

--- a/apps/web/src/components/slice.tsx
+++ b/apps/web/src/components/slice.tsx
@@ -1481,7 +1481,7 @@ const ExtraSliceControls = <T extends ValidComponent = "div">(
   return (
     <div
       class={cn(
-        "grid grid-rows-4 gap-1 py-1 opacity-75 [&_svg]:pointer-events-none [&_svg]:size-full *:aspect-square",
+        "grid grid-rows-4 py-1 gap-1 opacity-75 [&_svg]:pointer-events-none [&_svg]:h-full *:aspect-square",
         local.class,
       )}
       {...others}

--- a/apps/web/src/context/audio.tsx
+++ b/apps/web/src/context/audio.tsx
@@ -210,11 +210,14 @@ export const AudioProvider: ParentComponent = (props) => {
         return;
       const promise = radio()?.createDaxRxAudioStream({ daxChannel });
       promise?.then((controller) =>
-        daxRxControllers.set(controller.daxChannel, controller),
+        daxRxControllers.set(daxChannel, controller),
       );
       onCleanup(() =>
         promise?.then((stream) => {
-          daxRxControllers.delete(stream.daxChannel);
+          // Use the captured daxChannel local, not stream.daxChannel: on
+          // disconnect the store snapshot is already gone, so reading the
+          // getter would throw FlexStateUnavailableError.
+          daxRxControllers.delete(daxChannel);
           radio()?.audioStream(stream.id)?.close();
         }),
       );

--- a/apps/web/src/context/panafall.tsx
+++ b/apps/web/src/context/panafall.tsx
@@ -18,6 +18,7 @@ import {
   type WaterfallController,
 } from "@repo/flexlib";
 import { createElementBounds } from "@solid-primitives/bounds";
+import { createElementSize } from "@solid-primitives/resize-observer";
 import { usePreferences } from "./preferences";
 import { roundToDecimals } from "~/lib/utils";
 import { onlyAncestorMutations } from "~/lib/element-bounds";
@@ -51,6 +52,14 @@ const PanafallContext = createContext<{
   mhzToPx: (mhz: number) => number;
   /** The current panadapter state object from the radio. */
   panadapter: Accessor<PanadapterState>;
+  /** Sets the panadapter wrapper element so the context can track its size. */
+  setPanadapterWrapper: (el: HTMLElement) => void;
+  /**
+   * Reactive size of the panadapter wrapper (the canvas's CSS box). This is the
+   * coordinate space mouse events live in, so all freq<->pixel math keys off its
+   * width rather than `pan.width` (the radio's integer dimension).
+   */
+  panadapterWrapperSize: ReturnType<typeof createElementSize>;
   /** Controller for sending commands to the panadapter (pan, zoom, etc.). */
   panadapterController: Accessor<PanadapterController>;
   /** Reactive bounding rect of the panadapter/waterfall element. */
@@ -92,6 +101,8 @@ export const PanafallProvider: ParentComponent<{ streamId?: string }> = (
     createSignal<HTMLElement>();
   const [panadapterControlsRef, setPanadapterControlsRef] =
     createSignal<HTMLElement>();
+  const [panadapterWrapper, setPanadapterWrapper] = createSignal<HTMLElement>();
+  const panadapterWrapperSize = createElementSize(panadapterWrapper);
   const panafallBounds = createElementBounds(panafallControlsRef, {
     trackMutation: onlyAncestorMutations(panafallControlsRef),
   });
@@ -120,48 +131,52 @@ export const PanafallProvider: ParentComponent<{ streamId?: string }> = (
 
   const pxPerMHz = createMemo(() => {
     const pan = panadapter();
-    if (!pan || !pan.bandwidthMHz || !pan.width) return 0;
-    return pan.width / pan.bandwidthMHz;
+    const width = panadapterWrapperSize.width;
+    if (!pan || !pan.bandwidthMHz || !width) return 0;
+    return width / pan.bandwidthMHz;
   });
 
   const mhzPerPx = createMemo(() => {
     const pan = panadapter();
-    if (!pan || !pan.bandwidthMHz || !pan.width) return 0;
-    return pan.bandwidthMHz / pan.width;
+    const width = panadapterWrapperSize.width;
+    if (!pan || !pan.bandwidthMHz || !width) return 0;
+    return pan.bandwidthMHz / width;
   });
 
   const mhzToPx = (mhz: number) => {
     const pan = panadapter();
-    if (!pan || !pan.bandwidthMHz || !pan.width) return 0;
+    if (!pan || !pan.bandwidthMHz || !panadapterWrapperSize.width) return 0;
     return mhz * pxPerMHz();
   };
 
   const pxToMHz = (px: number) => {
     const pan = panadapter();
-    if (!pan || !pan.bandwidthMHz || !pan.width) return 0;
+    if (!pan || !pan.bandwidthMHz || !panadapterWrapperSize.width) return 0;
     return roundToDecimals(px * mhzPerPx(), 6);
   };
 
   const xToFreq = (x: number) => {
     const pan = panadapter();
-    if (!pan || !pan.bandwidthMHz || !pan.width) return 0;
+    const width = panadapterWrapperSize.width;
+    if (!pan || !pan.bandwidthMHz || !width) return 0;
     const centerFreq = pan.centerFrequencyMHz;
     const offsetPx = preferences.enableTransparencyEffects
       ? x
       : x - panafallBounds.left;
-    const offsetMHz = pxToMHz(offsetPx - pan.width / 2);
+    const offsetMHz = pxToMHz(offsetPx - width / 2);
     return roundToDecimals(centerFreq + offsetMHz, 6);
   };
 
   const freqToX = (freq: number) => {
     const pan = panadapter();
-    if (!pan || !pan.bandwidthMHz || !pan.width) return 0;
+    const width = panadapterWrapperSize.width;
+    if (!pan || !pan.bandwidthMHz || !width) return 0;
     const centerFreq = pan.centerFrequencyMHz;
     const offsetMHz = freq - centerFreq;
     const offsetPx = preferences.enableTransparencyEffects
       ? 0
       : panafallBounds.left;
-    return pan.width / 2 + mhzToPx(offsetMHz) + offsetPx;
+    return width / 2 + mhzToPx(offsetMHz) + offsetPx;
   };
 
   return (
@@ -180,6 +195,8 @@ export const PanafallProvider: ParentComponent<{ streamId?: string }> = (
           mhzPerPx,
           mhzToPx,
           panadapter,
+          setPanadapterWrapper,
+          panadapterWrapperSize,
           panadapterController,
           panafallBounds,
           pxPerMHz,

--- a/apps/web/src/lib/dax-audio-sink/dax-audio-sink.ts
+++ b/apps/web/src/lib/dax-audio-sink/dax-audio-sink.ts
@@ -58,7 +58,15 @@ export class DaxAudioSink {
 
   async init(): Promise<void> {
     if (this.closed) return;
-    await this.ctx.audioWorklet.addModule(sabWorkletURL);
+    try {
+      await this.ctx.audioWorklet.addModule(sabWorkletURL);
+    } catch (err) {
+      // close() can race the in-flight addModule (e.g. the sink is torn
+      // down during a reconnect before the worklet finishes loading),
+      // closing the AudioContext and rejecting with AbortError. Benign.
+      if (this.closed) return;
+      throw err;
+    }
     if (this.closed) return;
     const node = new AudioWorkletNode(this.ctx, "sab-ring-sink", {
       numberOfInputs: 0,

--- a/apps/web/src/lib/dax-iq-audio-sink/dax-iq-audio-sink.ts
+++ b/apps/web/src/lib/dax-iq-audio-sink/dax-iq-audio-sink.ts
@@ -41,7 +41,15 @@ export class DaxIqAudioSink {
 
   async init(): Promise<void> {
     if (this.closed) return;
-    await this.ctx.audioWorklet.addModule(sabWorkletURL);
+    try {
+      await this.ctx.audioWorklet.addModule(sabWorkletURL);
+    } catch (err) {
+      // close() can race the in-flight addModule (e.g. the sink is torn
+      // down during a reconnect before the worklet finishes loading),
+      // closing the AudioContext and rejecting with AbortError. Benign.
+      if (this.closed) return;
+      throw err;
+    }
     if (this.closed) return;
     const node = new AudioWorkletNode(this.ctx, "sab-ring-sink", {
       numberOfInputs: 0,

--- a/apps/web/src/lib/device-scale.ts
+++ b/apps/web/src/lib/device-scale.ts
@@ -1,0 +1,25 @@
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+
+const onChange = () =>
+  setPixelDensity(Math.max(window.devicePixelRatio || 1, 1));
+
+const [pixelDensity, setPixelDensity] = createSignal(
+  Math.max(window.devicePixelRatio || 1, 1),
+);
+
+createEffect(() => {
+  // A resolution media query only fires when it stops matching its fixed
+  // value, so re-subscribe whenever the density changes. This catches the
+  // window moving to a monitor with a different DPR, where the CSS wrapper
+  // size is unchanged but the device-pixel size isn't.
+  const current = pixelDensity();
+  const query = window.matchMedia(`(resolution: ${current}dppx)`);
+  query.addEventListener("change", onChange);
+  onCleanup(() => query.removeEventListener("change", onChange));
+});
+
+// Snap a device-pixel ratio to its integer scale bucket; bins map to whole
+// device pixels only at integer scales.
+const deviceScale = createMemo(() => Math.max(1, Math.round(pixelDensity())));
+
+export { pixelDensity, deviceScale };

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -39,7 +39,7 @@ export function degToRad(deg: number): number {
 }
 
 export function roundToDevicePixels(px: number) {
-  const dpr = Number(window.devicePixelRatio?.toFixed(2) || 1);
+  const dpr = Number(window.devicePixelRatio?.toFixed(6) || 1);
   return Math.round(px * dpr) / dpr;
 }
 

--- a/packages/flexlib/src/flex/radio-core.ts
+++ b/packages/flexlib/src/flex/radio-core.ts
@@ -142,7 +142,11 @@ import type {
   FilterPresetStateChange,
   WaveformStateChange,
 } from "./state/index.js";
-import { parseVitaPacket, type VitaPacket } from "../vita/parser.js";
+import {
+  parseVitaPacket,
+  type VitaPacket,
+  type ParseVitaPacketOptions,
+} from "../vita/parser.js";
 import { VitaMeterPacket } from "../vita/meter-packet.js";
 import { getModelInfo, type RadioModelInfo } from "./model-info.js";
 import {
@@ -521,6 +525,25 @@ class RadioImpl {
   // Stream handler registries for UDP data routing
   private readonly streamHandlers = new Map<number, Set<StreamPacketHandler>>();
   private readonly meterHandlers = new Map<number, Set<MeterValueHandler>>();
+
+  // Reusable scratch buffers for VITA payload parsing. handleUdpData processes
+  // one packet to completion (parse → synchronous dispatch → consumed) before
+  // the next, so a single shared scratch per kind is safe and avoids a fresh
+  // typed-array allocation on every packet. This holds across multiple streams
+  // of the same kind (e.g. several DAX channels) because each packet is fully
+  // consumed before the next reuses the buffer. Consumers must read/copy the
+  // payload synchronously within their handler — verified: panadapter/waterfall
+  // draw synchronously, meter reads inline, and DAX audio/IQ postMessage a
+  // structured clone (not a transfer) to their worker. The parsers grow each
+  // buffer in place as needed.
+  private readonly vitaParseScratch: ParseVitaPacketOptions = {
+    meter: {},
+    panadapter: {},
+    waterfall: {},
+    daxAudio: {},
+    daxReducedBw: {},
+    daxIq: {},
+  };
 
   // Controller caches
   private readonly sliceControllers = new Map<string, SliceControllerImpl>();
@@ -2760,7 +2783,7 @@ class RadioImpl {
   // -----------------------------------------------------------------------
 
   private handleUdpData(data: Uint8Array): void {
-    const parsed = parseVitaPacket(data);
+    const parsed = parseVitaPacket(data, this.vitaParseScratch);
     if (!parsed) {
       this.logger?.warn?.("Unhandled UDP packet", {
         payloadLength: data.byteLength,

--- a/packages/flexlib/src/util/waterfall-tile.ts
+++ b/packages/flexlib/src/util/waterfall-tile.ts
@@ -1,10 +1,11 @@
-// WaterfallTile model (ported from Flex.Util.WaterfallTile)
-import { VitaFrequency } from "./vita-frequency";
+// Per-frame waterfall metadata parsed from a VITA waterfall packet.
+//
+// NOTE: This is *not* the buffered/timestamped "tile" of the C# Flex.Util
+// library — we render each packet straight to the offscreen canvas as it
+// arrives and never assemble or retain completed frames. This is just the
+// flat set of header fields the renderer reads off each packet.
+import type { VitaFrequency } from "./vita-frequency";
 
-/**
- * Represents a single Waterfall Tile object.
- * Mirrors the C# class, using idiomatic TS names and types.
- */
 export interface WaterfallTile {
   /** The frequency (Hz) represented by the first bin in the frame. */
   frameLowFreq: VitaFrequency;
@@ -38,51 +39,6 @@ export interface WaterfallTile {
   /** Auto-black (noise floor) level used by the renderer. */
   autoBlackLevel: number; // uint32
 
-  /**
-   * If the frame spans multiple packets, this becomes true when all have arrived.
-   */
-  isFrameComplete: boolean;
-
   /** Waterfall bin data; length is typically width * height. */
   data: Uint16Array;
-
-  /** Arrival timestamp (UTC) assigned by the receiver. */
-  dateTime: Date;
-}
-
-/** Create a tile with sensible defaults; pass any fields to override. */
-export function createWaterfallTile(
-  init: Partial<WaterfallTile> = {},
-): WaterfallTile {
-  return {
-    frameLowFreq: init.frameLowFreq ?? VitaFrequency.fromHz(0),
-    firstBinIndex: init.firstBinIndex ?? 0,
-    totalBinsInFrame: init.totalBinsInFrame ?? 0,
-    binBandwidth: init.binBandwidth ?? VitaFrequency.fromHz(0),
-    lineDurationMs: init.lineDurationMs ?? 0,
-    width: init.width ?? 0,
-    height: init.height ?? 0,
-    timecode: init.timecode ?? 0,
-    autoBlackLevel: init.autoBlackLevel ?? 0,
-    isFrameComplete: init.isFrameComplete ?? false,
-    data: init.data ?? new Uint16Array(0),
-    dateTime: init.dateTime ?? new Date(),
-  };
-}
-
-/**
- * Format like the C# ToString():
- *   Timecode + ": " + FrameLowFreq(f6) + "  " + WxH + " " + LineDurationMS + "ms " + hh:mm:ss.fff
- * Uses UTC clock (the C# used DateTime.UtcNow for assignment).
- */
-export function formatWaterfallTile(t: WaterfallTile): string {
-  const two = (n: number) => (n < 10 ? `0${n}` : `${n}`);
-  const three = (n: number) => n.toString().padStart(3, "0");
-  const d = t.dateTime;
-  const hours12 = ((d.getUTCHours() + 11) % 12) + 1;
-  const hh = two(hours12);
-  const mm = two(d.getUTCMinutes());
-  const ss = two(d.getUTCSeconds());
-  const fff = three(d.getUTCMilliseconds());
-  return `${t.timecode}: ${t.frameLowFreq.freqMhz.toFixed(6)}  ${t.width}x${t.height} ${t.lineDurationMs}ms ${hh}:${mm}:${ss}.${fff}`;
 }

--- a/packages/flexlib/src/vita/parser.ts
+++ b/packages/flexlib/src/vita/parser.ts
@@ -39,6 +39,9 @@ export interface ParseVitaPacketOptions {
   meter?: { ids?: Uint16Array; values?: Int16Array };
   panadapter?: { payload?: Uint16Array };
   waterfall?: { data?: Uint16Array };
+  daxAudio?: { left?: Float32Array; right?: Float32Array };
+  daxReducedBw?: { samples?: Int16Array };
+  daxIq?: { left?: Float32Array; right?: Float32Array };
 }
 
 const PACKET_CLASS_METER = 0x8002;
@@ -82,7 +85,7 @@ export function parseVitaPacket(
     }
     case VITA_FLEX_DAX_REDUCED_BW_CLASS: {
       const packet = new VitaDaxReducedBwPacket();
-      packet.parseWithContext(ctx);
+      packet.parseWithContext(ctx, options.daxReducedBw);
       return packet;
     }
     case VITA_FLEX_DAX_IQ_24_CLASS:
@@ -90,12 +93,12 @@ export function parseVitaPacket(
     case VITA_FLEX_DAX_IQ_96_CLASS:
     case VITA_FLEX_DAX_IQ_192_CLASS: {
       const packet = new VitaDaxIqPacket();
-      packet.parseWithContext(ctx);
+      packet.parseWithContext(ctx, options.daxIq);
       return packet;
     }
     case VITA_FLEX_DAX_AUDIO_CLASS: {
       const packet = new VitaDaxAudioPacket();
-      packet.parseWithContext(ctx);
+      packet.parseWithContext(ctx, options.daxAudio);
       return packet;
     }
     default:

--- a/packages/flexlib/src/vita/waterfall-packet.ts
+++ b/packages/flexlib/src/vita/waterfall-packet.ts
@@ -47,7 +47,6 @@ export class VitaWaterfallPacket {
     };
     this.classId = { oui: 0, informationClassCode: 0, packetClassCode: 0 };
     this.tile = {
-      dateTime: new Date(),
       frameLowFreq: VitaFrequency.fromHz(0),
       binBandwidth: VitaFrequency.fromHz(0),
       lineDurationMs: 0,
@@ -57,7 +56,6 @@ export class VitaWaterfallPacket {
       autoBlackLevel: 0,
       totalBinsInFrame: 0,
       firstBinIndex: 0,
-      isFrameComplete: false,
       data: new Uint16Array(0),
     };
     this.trailer = emptyTrailer();
@@ -181,7 +179,6 @@ export class VitaWaterfallPacket {
     const payloadEnd = ctx.payloadOffset + ctx.payloadLength;
 
     const tile = this.tile;
-    tile.dateTime = new Date();
 
     if (off + TILE_HEADER_BYTES > payloadEnd) {
       tile.frameLowFreq = VitaFrequency.fromHz(0);
@@ -193,7 +190,6 @@ export class VitaWaterfallPacket {
       tile.autoBlackLevel = 0;
       tile.totalBinsInFrame = 0;
       tile.firstBinIndex = 0;
-      tile.isFrameComplete = false;
       tile.data =
         out?.data && out.data.length
           ? out.data.subarray(0, 0)


### PR DESCRIPTION
## Panadapter Drawing Overhaul

Panadapter drawing has undergone a complete overhaul. There are two primary changes:

### Drawing in a Web Worker

Drawing now happens in a worker, moving the expensive canvas operations off of the main thread so they no longer hold up the stream of events coming from the radio. Raw rendering performance is likely unchanged since it will be mostly GPU bound (especially on large screens), but drawing operations are no longer competing for resources with things like DAX, which helps keep latency low and prevent dropouts. Since rendering now happens in a separate thread, we're able to make better use of device resources and devices that were marginal before (like older phones, tablets, etc) may be much more usable now.

### Always Sharp

Previously, on devices with an uneven device pixel ratio (DPR), the panadapter could appear blurry. This was a common problem with Windows devices (125% scale) or when using a browser zoom of anything other than 100%. With the new drawing changes, we're now able to ensure that the panadapter is razor-sharp on all devices at all zoom levels.

## Other Improvements

- VITA parsing uses scratch buffers to reduce parsing overhead (improves performance of panadapter, waterfall, meters, DAX)
- Frequency positioned elements are placed more precisely (DPR was being rounded to only 2 decimals, now 6. Mostly affects zoom levels in Firefox but could help in other scenarios)
- The FPS window can be closed with a context menu
- Connect/disconnect manages resources like audio streams better to cut down on console noise