### PR TITLE
Restore waterfall panel (regression from #33)

### DIFF
--- a/apps/web/src/components/panafall/panafall.tsx
+++ b/apps/web/src/components/panafall/panafall.tsx
@@ -364,7 +364,7 @@ export function Panafall(props: { index: number }) {
                     );
                     if (
                       isNaN(panHeight) ||
-                      panHeight === preferences.panadapterSizes[props.index][0]
+                      panHeight === preferences.panadapterSizes[props.index]?.[0]
                     ) {
                       return;
                     }


### PR DESCRIPTION
### Problem

After #33, the waterfall no longer renders — only the panadapter (spectrum) shows. On connect the console throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at onSizesChange (panafall.tsx)
    at Object.registerPanel (@corvu/resizable)
```

followed by a flood of `distributePercentage … reading 'data'` errors when dragging the panafall divider.

### Root cause

`onSizesChange` compares against `preferences.panadapterSizes[props.index][0]`, but `panadapterSizes` defaults to `[]`, so `panadapterSizes[props.index]` is `undefined` and `[0]` throws. corvu invokes `onSizesChange` **during panel registration at mount**, so the exception aborts registration of the second (waterfall) panel — it ends up zero-height, leaving the spectrum visible and the waterfall gone.

### Fix

Guard the access with optional chaining (`?.[0]`). When the preference is unset the comparison is against `undefined` (falsy), so the size is stored normally and panel registration completes.

Verified on a live radio: waterfall renders again and the resize-drag errors are gone.
