### PR TITLE
Drive AF Input Level meter from the browser mic stream

### DIFF
--- a/apps/web/src/components/right-sidebar.tsx
+++ b/apps/web/src/components/right-sidebar.tsx
@@ -28,6 +28,8 @@ import { SimpleSwitch } from "./ui/simple-switch";
 import { dbmToWatts, roundToDecimals } from "~/lib/utils";
 import { debounce } from "@solid-primitives/scheduled";
 import { SimpleMeter } from "./ui/simple-meter";
+import { useAudio } from "~/context/audio";
+import { createStreamLevel } from "~/lib/stream-level";
 import { SliderToggle } from "./ui/slider-toggle";
 import {
   SegmentedControl,
@@ -399,16 +401,12 @@ function TxSection() {
 
 function MicSection() {
   const { state, radio } = useFlexRadio();
-  const [micPeakValue, setMicPeakValue] = createSignal(-150);
+  const { remoteAudioTxStream } = useAudio();
   const [compPeakValue, setCompPeakValue] = createSignal(-150);
   const [createProfile, setCreateProfile] = createSignal(false);
 
   const micMeter = createMemo(() =>
     Object.values(state.status.meter).find((meter) => meter.name === "MIC"),
-  );
-
-  const micPeakMeter = createMemo(() =>
-    Object.values(state.status.meter).find((meter) => meter.name === "MICPEAK"),
   );
 
   const compPeakMeter = createMemo(() =>
@@ -417,15 +415,18 @@ function MicSection() {
     ),
   );
 
-  createEffect(() => {
-    if (!state.status.radio.meterInRx && !state.status.radio.mox)
-      return setMicPeakValue(-150);
+  // The radio's MIC/MICPEAK meters don't reflect the browser's network TX-audio
+  // path (they read the radio's own mic input), so derive the AF input level
+  // straight from the microphone stream the browser is sending.
+  const { level: afInputLevel, peak: afInputPeak } =
+    createStreamLevel(remoteAudioTxStream);
 
-    const sub = radio()
-      ?.meter(micPeakMeter()?.id)
-      ?.on("data", ({ value }) => setMicPeakValue(roundToDecimals(value, 1)));
-    onCleanup(() => sub?.unsubscribe());
-  });
+  // Reading shown while transmitting (or when meters are enabled in RX);
+  // floored to the meter minimum so it reads empty when idle.
+  const afInputReading = (value: number) =>
+    !state.status.radio.meterInRx && !state.status.radio.mox
+      ? -40
+      : Math.max(value, -40);
 
   createEffect(() => {
     if (
@@ -454,15 +455,11 @@ function MicSection() {
           return (
             <SimpleMeter
               meter={meter}
-              peakValue={micPeakValue()}
-              value={
-                !state.status.radio.meterInRx && !state.status.radio.mox
-                  ? -150
-                  : undefined
-              }
+              peakValue={afInputReading(afInputPeak())}
+              value={afInputReading(afInputLevel())}
               minValue={-40}
               maxValue={0}
-              getValueLabel={() => `${micPeakValue().toFixed(1)} dB`}
+              getValueLabel={() => `${afInputReading(afInputPeak()).toFixed(1)} dB`}
               label="AF Input Level"
               showTicks
               showTickLabels

--- a/apps/web/src/components/right-sidebar.tsx
+++ b/apps/web/src/components/right-sidebar.tsx
@@ -402,11 +402,16 @@ function TxSection() {
 function MicSection() {
   const { state, radio } = useFlexRadio();
   const { remoteAudioTxStream } = useAudio();
+  const [micPeakValue, setMicPeakValue] = createSignal(-150);
   const [compPeakValue, setCompPeakValue] = createSignal(-150);
   const [createProfile, setCreateProfile] = createSignal(false);
 
   const micMeter = createMemo(() =>
     Object.values(state.status.meter).find((meter) => meter.name === "MIC"),
+  );
+
+  const micPeakMeter = createMemo(() =>
+    Object.values(state.status.meter).find((meter) => meter.name === "MICPEAK"),
   );
 
   const compPeakMeter = createMemo(() =>
@@ -415,18 +420,42 @@ function MicSection() {
     ),
   );
 
-  // The radio's MIC/MICPEAK meters don't reflect the browser's network TX-audio
-  // path (they read the radio's own mic input), so derive the AF input level
-  // straight from the microphone stream the browser is sending.
-  const { level: afInputLevel, peak: afInputPeak } =
-    createStreamLevel(remoteAudioTxStream);
+  // The radio's MIC/MICPEAK meters cover its physical inputs (MIC/BAL/LINE/ACC)
+  // and DAX, but read silence for the browser's network TX-audio path (the PC
+  // input with DAX off), so only that case derives the AF input level from the
+  // microphone stream the browser is sending — same behavior as SmartSDR.
+  const useBrowserLevel = createMemo(
+    () =>
+      state.status.radio.micSelection === "PC" &&
+      !state.status.radio.daxEnabled,
+  );
 
-  // Reading shown while transmitting (or when meters are enabled in RX);
-  // floored to the meter minimum so it reads empty when idle.
-  const afInputReading = (value: number) =>
+  const { level: browserLevel, peak: browserPeak } = createStreamLevel(() =>
+    useBrowserLevel() ? remoteAudioTxStream() : undefined,
+  );
+
+  // Browser reading shown while transmitting (or when meters are enabled in
+  // RX); floored to the meter minimum so it reads empty when idle.
+  const browserReading = (value: number) =>
     !state.status.radio.meterInRx && !state.status.radio.mox
       ? -40
       : Math.max(value, -40);
+
+  const afInputPeak = () =>
+    useBrowserLevel() ? browserReading(browserPeak()) : micPeakValue();
+
+  createEffect(() => {
+    if (
+      useBrowserLevel() ||
+      (!state.status.radio.meterInRx && !state.status.radio.mox)
+    )
+      return setMicPeakValue(-150);
+
+    const sub = radio()
+      ?.meter(micPeakMeter()?.id)
+      ?.on("data", ({ value }) => setMicPeakValue(roundToDecimals(value, 1)));
+    onCleanup(() => sub?.unsubscribe());
+  });
 
   createEffect(() => {
     if (
@@ -455,11 +484,17 @@ function MicSection() {
           return (
             <SimpleMeter
               meter={meter}
-              peakValue={afInputReading(afInputPeak())}
-              value={afInputReading(afInputLevel())}
+              peakValue={afInputPeak()}
+              value={
+                useBrowserLevel()
+                  ? browserReading(browserLevel())
+                  : !state.status.radio.meterInRx && !state.status.radio.mox
+                    ? -150
+                    : undefined
+              }
               minValue={-40}
               maxValue={0}
-              getValueLabel={() => `${afInputReading(afInputPeak()).toFixed(1)} dB`}
+              getValueLabel={() => `${afInputPeak().toFixed(1)} dB`}
               label="AF Input Level"
               showTicks
               showTickLabels

--- a/apps/web/src/components/ui/audio-level-meter.tsx
+++ b/apps/web/src/components/ui/audio-level-meter.tsx
@@ -1,7 +1,7 @@
-import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { SimpleMeter } from "./simple-meter";
 import type { DaxChannelMode } from "~/lib/dax-audio-sink/types";
 import type { MeterState } from "~/context/flexradio";
+import { createStreamLevel } from "~/lib/stream-level";
 
 const METER: MeterState = {
   id: "",
@@ -15,80 +15,15 @@ const METER: MeterState = {
   description: "",
 };
 
-const PEAK_HOLD = 120;
-const PEAK_DECAY = 0.2;
-
 export function AudioLevelMeter(props: {
   label?: string | undefined;
   stream: MediaStream | undefined;
   channelMode: DaxChannelMode;
 }) {
-  const [level, setLevel] = createSignal(-Infinity);
-  const [peak, setPeak] = createSignal(-Infinity);
-
-  createEffect(() => {
-    const stream = props.stream;
-    if (!stream) {
-      setLevel(-Infinity);
-      setPeak(-Infinity);
-      return;
-    }
-
-    const ctx = new AudioContext();
-    const source = ctx.createMediaStreamSource(stream);
-    const analyser = ctx.createAnalyser();
-    analyser.fftSize = 256;
-    const buf = new Float32Array(analyser.fftSize);
-
-    if (props.channelMode === "both") {
-      source.connect(analyser);
-    } else {
-      const splitter = ctx.createChannelSplitter(2);
-      source.connect(splitter);
-      splitter.connect(analyser, props.channelMode === "left" ? 0 : 1);
-    }
-
-    let smoothedRms = 0;
-    let currentPeak = -Infinity;
-    let peakHoldFrames = 0;
-    let rafId: number;
-
-    const tick = () => {
-      analyser.getFloatTimeDomainData(buf as Float32Array<ArrayBuffer>);
-      let sum = 0;
-      let maxAbs = 0;
-      for (const s of buf) {
-        sum += s * s;
-        const abs = Math.abs(s);
-        if (abs > maxAbs) maxAbs = abs;
-      }
-      const rms = Math.sqrt(sum / buf.length);
-      const alpha = rms > smoothedRms ? 0.3 : 0.05;
-      smoothedRms = alpha * rms + (1 - alpha) * smoothedRms;
-
-      const peakDb = 20 * Math.log10(Math.max(maxAbs, 1e-7));
-      if (peakDb >= currentPeak) {
-        currentPeak = peakDb;
-        peakHoldFrames = PEAK_HOLD;
-      } else if (peakHoldFrames > 0) {
-        peakHoldFrames--;
-      } else {
-        currentPeak = Math.max(currentPeak - PEAK_DECAY, peakDb);
-      }
-
-      setLevel(20 * Math.log10(Math.max(smoothedRms, 1e-7)));
-      setPeak(currentPeak);
-      rafId = requestAnimationFrame(tick);
-    };
-    rafId = requestAnimationFrame(tick);
-
-    onCleanup(() => {
-      cancelAnimationFrame(rafId);
-      source.disconnect();
-      analyser.disconnect();
-      void ctx.close();
-    });
-  });
+  const { level, peak } = createStreamLevel(
+    () => props.stream,
+    () => props.channelMode,
+  );
 
   return (
     <div

--- a/apps/web/src/lib/stream-level.ts
+++ b/apps/web/src/lib/stream-level.ts
@@ -1,0 +1,93 @@
+import { createEffect, createSignal, onCleanup, type Accessor } from "solid-js";
+import type { DaxChannelMode } from "~/lib/dax-audio-sink/types";
+
+const PEAK_HOLD = 120;
+const PEAK_DECAY = 0.2;
+
+export interface StreamLevel {
+  /** Smoothed RMS level in dBFS (-Infinity when no stream/signal). */
+  level: Accessor<number>;
+  /** Peak-hold level in dBFS (-Infinity when no stream/signal). */
+  peak: Accessor<number>;
+}
+
+/**
+ * Derives a smoothed RMS level (dBFS) and a peak-hold value from a MediaStream
+ * using the Web Audio API. This reflects the browser's own view of the audio —
+ * e.g. the microphone the browser has access to — independent of any radio-side
+ * meter. Returns -Infinity for both while there is no stream.
+ */
+export function createStreamLevel(
+  stream: Accessor<MediaStream | undefined>,
+  channelMode: Accessor<DaxChannelMode> = () => "both",
+): StreamLevel {
+  const [level, setLevel] = createSignal(-Infinity);
+  const [peak, setPeak] = createSignal(-Infinity);
+
+  createEffect(() => {
+    const src = stream();
+    if (!src) {
+      setLevel(-Infinity);
+      setPeak(-Infinity);
+      return;
+    }
+
+    const mode = channelMode();
+    const ctx = new AudioContext();
+    const source = ctx.createMediaStreamSource(src);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 256;
+    const buf = new Float32Array(analyser.fftSize);
+
+    if (mode === "both") {
+      source.connect(analyser);
+    } else {
+      const splitter = ctx.createChannelSplitter(2);
+      source.connect(splitter);
+      splitter.connect(analyser, mode === "left" ? 0 : 1);
+    }
+
+    let smoothedRms = 0;
+    let currentPeak = -Infinity;
+    let peakHoldFrames = 0;
+    let rafId: number;
+
+    const tick = () => {
+      analyser.getFloatTimeDomainData(buf as Float32Array<ArrayBuffer>);
+      let sum = 0;
+      let maxAbs = 0;
+      for (const sample of buf) {
+        sum += sample * sample;
+        const abs = Math.abs(sample);
+        if (abs > maxAbs) maxAbs = abs;
+      }
+      const rms = Math.sqrt(sum / buf.length);
+      const alpha = rms > smoothedRms ? 0.3 : 0.05;
+      smoothedRms = alpha * rms + (1 - alpha) * smoothedRms;
+
+      const peakDb = 20 * Math.log10(Math.max(maxAbs, 1e-7));
+      if (peakDb >= currentPeak) {
+        currentPeak = peakDb;
+        peakHoldFrames = PEAK_HOLD;
+      } else if (peakHoldFrames > 0) {
+        peakHoldFrames--;
+      } else {
+        currentPeak = Math.max(currentPeak - PEAK_DECAY, peakDb);
+      }
+
+      setLevel(20 * Math.log10(Math.max(smoothedRms, 1e-7)));
+      setPeak(currentPeak);
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+
+    onCleanup(() => {
+      cancelAnimationFrame(rafId);
+      source.disconnect();
+      analyser.disconnect();
+      void ctx.close();
+    });
+  });
+
+  return { level, peak };
+}


### PR DESCRIPTION
### Problem

The **AF Input Level** meter never reflects the transmitted microphone, even though TX audio works correctly.

### Root cause

- The meter's fill was bound to `SimpleMeter`'s internal `value()`, which subscribes to the radio's **`MIC`** meter — that meter never streams (stays at its initial `0`, so the bar renders full).
- The peak indicator and label use the **`MICPEAK`** meter, which *does* stream but reads silence (~-100 dBFS during active TX on a FLEX-8000). The radio's mic meters don't reflect the browser's network TX-audio path.

### Fix

Extract the Web-Audio level analysis out of `AudioLevelMeter` into a reusable `createStreamLevel()` hook, and drive the AF Input Level meter from `remoteAudioTxStream()` — the microphone stream the browser actually sends to the radio. This makes the meter reflect the mic the browser has access to.

Verified on a live radio: the bar and peak now track speech.

### Note

This changes what the meter measures (radio-reported level → browser-local level). Happy to adjust if you'd prefer to keep it radio-sourced and instead address mic metering on the radio side.
