### PR TITLE
Add a touch-specific frequency input

### DIFF
--- a/apps/web/src/components/panafall/panafalls.tsx
+++ b/apps/web/src/components/panafall/panafalls.tsx
@@ -6,6 +6,7 @@ import { PanafallSettingsSidebar, PanSettings } from "./settings";
 import { Panafall } from "./panafall";
 import BaselineDisplaySettings from "~icons/ic/baseline-display-settings";
 import { usePreferences } from "~/context/preferences";
+import { TuningPanel } from "../tuning-panel";
 
 export function Panafalls() {
   const { state } = useFlexRadio();
@@ -55,6 +56,7 @@ export function Panafalls() {
           </PanafallProvider>
         )}
       </For>
+      <TuningPanel />
     </div>
   );
 }

--- a/apps/web/src/components/slice.tsx
+++ b/apps/web/src/components/slice.tsx
@@ -1544,7 +1544,7 @@ export function Slice(props: { slice: SliceState; pan: PanadapterState }) {
     trackMutation: onlyAncestorMutations(flag),
   });
   const { preferences } = usePreferences();
-  const { runtime } = useRuntime();
+  const { runtime, setRuntime } = useRuntime();
   const { dispatch } = useControls();
   const [compactLayout, setCompactLayout] = createSignal(false);
 
@@ -2008,6 +2008,18 @@ export function Slice(props: { slice: SliceState; pan: PanadapterState }) {
                             size={14}
                             valueHz={Math.round(props.slice.frequencyMHz * 1e6)}
                             onCommit={tuneSlice}
+                            // `on:touchstart` binds directly to the element
+                            // (non-passive); the camelCase `onTouchStart` is
+                            // delegated to document, where Chrome forces passive
+                            // and preventDefault() is ignored. We need
+                            // preventDefault to open the panel instead of
+                            // focusing the input (which pops the soft keyboard).
+                            // Fires only on touch, so mouse/pen keep inline edit.
+                            on:touchstart={(event) => {
+                              event.preventDefault();
+                              makeActive();
+                              setRuntime("tuningPanelOpen", true);
+                            }}
                           />
                         </div>
                       </Show>

--- a/apps/web/src/components/tuning-panel.tsx
+++ b/apps/web/src/components/tuning-panel.tsx
@@ -1,0 +1,169 @@
+import {
+  Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  on,
+  Show,
+} from "solid-js";
+import useFlexRadio from "~/context/flexradio";
+import { useRuntime } from "~/context/runtime";
+import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
+import { Button } from "./ui/button";
+import MaterialSymbolsKeyboardArrowUp from "~icons/material-symbols/keyboard-arrow-up";
+import MaterialSymbolsKeyboardArrowDown from "~icons/material-symbols/keyboard-arrow-down";
+
+const digitCount = (value: number) =>
+  value < 10 ? 1 : Math.floor(Math.log10(value)) + 1;
+
+interface DigitColumn {
+  digit: number;
+  place: number;
+  leading: boolean;
+  separatorBefore: boolean;
+}
+
+export const TuningPanel: Component = () => {
+  const { radio, state } = useFlexRadio();
+  const { runtime, setRuntime } = useRuntime();
+
+  const activeSlice = createMemo(() =>
+    Object.values(state.status.slice).find(
+      (slice) => slice.isActive && slice.clientHandle === state.clientHandleInt,
+    ),
+  );
+  const activeId = createMemo(() => activeSlice()?.id);
+
+  // Drive the display from a local value while the panel is open, seeded from
+  // the slice on open and whenever the targeted slice changes. This mirrors the
+  // drag path: we don't read slice state mid-interaction, so rapid digit taps
+  // don't race the radio's frequency echo.
+  const [valueHz, setValueHz] = createSignal(0);
+
+  const seed = () => {
+    const slice = activeSlice();
+    setValueHz(slice ? Math.round(slice.frequencyMHz * 1e6) : 0);
+  };
+  createEffect(on(activeId, seed));
+  createEffect(
+    on(
+      () => runtime.tuningPanelOpen,
+      (open) => open && seed(),
+    ),
+  );
+
+  // Column count is stable across slices: the model's native ceiling, widened
+  // to cover the highest RF frequency reachable through any configured
+  // transverter (LO + the radio's ~55 MHz IF ceiling).
+  const columnCount = createMemo(() => {
+    const base = radio()?.modelInfo.has2Meters ? 9 : 8;
+    let maxHz = valueHz();
+    for (const id in state.status.xvtr) {
+      const xvtr = state.status.xvtr[id];
+      if (!xvtr?.valid) continue;
+      const maxRfMHz = xvtr.rfFreqMHz - xvtr.ifFreqMHz + 55;
+      maxHz = Math.max(maxHz, Math.round(maxRfMHz * 1e6));
+    }
+    return Math.max(base, digitCount(maxHz));
+  });
+
+  const columns = createMemo<DigitColumn[]>(() => {
+    const n = columnCount();
+    const hz = valueHz();
+    let firstSignificant = n - 1;
+    for (let c = 0; c < n; c++) {
+      if (Math.floor(hz / 10 ** (n - 1 - c)) % 10 !== 0) {
+        firstSignificant = c;
+        break;
+      }
+    }
+    const cols: DigitColumn[] = [];
+    for (let c = 0; c < n; c++) {
+      const place = 10 ** (n - 1 - c);
+      cols.push({
+        digit: Math.floor(hz / place) % 10,
+        place,
+        leading: c < firstSignificant,
+        separatorBefore: c > 0 && (n - c) % 3 === 0,
+      });
+    }
+    return cols;
+  });
+
+  const adjust = (deltaHz: number) => {
+    const slice = activeSlice();
+    if (!slice) return;
+    const next = Math.max(0, valueHz() + deltaHz);
+    setValueHz(next);
+    radio()
+      ?.slice(slice.id)
+      ?.setFrequency(next / 1e6, false);
+  };
+
+  return (
+    <Sheet
+      open={runtime.tuningPanelOpen && Boolean(activeSlice())}
+      onOpenChange={(open) => setRuntime("tuningPanelOpen", open)}
+      modal={false}
+      preventScroll={false}
+    >
+      <SheetContent
+        position="bottom"
+        hideOverlay
+        class="select-none pb-[max(1.5rem,env(safe-area-inset-bottom))] shadow-black"
+        onOpenAutoFocus={(e: Event) => e.preventDefault()}
+      >
+        <Show when={activeSlice()}>
+          {(slice) => (
+            <>
+              <SheetTitle>
+                Slice {slice().indexLetter} · {slice().mode}
+              </SheetTitle>
+              <div class="mx-auto flex max-w-full justify-center gap-1 py-2 font-mono">
+                <For each={columns()}>
+                  {(col) => (
+                    <>
+                      <Show when={col.separatorBefore}>
+                        <div
+                          class="flex w-2 shrink-0 items-center justify-center text-3xl text-muted-foreground sm:text-4xl"
+                          classList={{ "opacity-30": col.leading }}
+                        >
+                          .
+                        </div>
+                      </Show>
+                      <div class="flex min-w-0 max-w-10 flex-1 flex-col items-center gap-1">
+                        <Button
+                          variant="outline"
+                          aria-label={`Increase by ${col.place} Hz`}
+                          class="h-10 max-w-10 w-full touch-manipulation p-0 [&_svg]:size-5 sm:[&_svg]:size-6"
+                          onClick={() => adjust(col.place)}
+                        >
+                          <MaterialSymbolsKeyboardArrowUp />
+                        </Button>
+                        <span
+                          class="text-3xl tabular-nums sm:text-4xl"
+                          classList={{ "opacity-30": col.leading }}
+                        >
+                          {col.digit}
+                        </span>
+                        <Button
+                          variant="outline"
+                          aria-label={`Decrease by ${col.place} Hz`}
+                          class="h-10 w-full touch-manipulation p-0 [&_svg]:size-5 sm:[&_svg]:size-6"
+                          onClick={() => adjust(-col.place)}
+                        >
+                          <MaterialSymbolsKeyboardArrowDown />
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </For>
+              </div>
+            </>
+          )}
+        </Show>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,5 +1,5 @@
 import type { Component, ComponentProps, JSX, ValidComponent } from "solid-js";
-import { splitProps } from "solid-js";
+import { Show, splitProps } from "solid-js";
 
 import * as SheetPrimitive from "@kobalte/core/dialog";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
@@ -58,7 +58,7 @@ const SheetOverlay = <T extends ValidComponent = "div">(
 };
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[closed=]:duration-300 data-[expanded=]:duration-500 data-[expanded=]:animate-in data-[closed=]:animate-out",
+  "fixed z-50 gap-4 fancy-bg-background p-6 shadow-lg transition ease-in-out data-[closed=]:duration-300 data-[expanded=]:duration-500 data-[expanded=]:animate-in data-[closed=]:animate-out",
   {
     variants: {
       position: {
@@ -81,6 +81,7 @@ type DialogContentProps<T extends ValidComponent = "div"> =
     VariantProps<typeof sheetVariants> & {
       class?: string | undefined;
       children?: JSX.Element;
+      hideOverlay?: boolean;
     };
 
 const SheetContent = <T extends ValidComponent = "div">(
@@ -90,10 +91,13 @@ const SheetContent = <T extends ValidComponent = "div">(
     "position",
     "class",
     "children",
+    "hideOverlay",
   ]);
   return (
     <SheetPortal position={local.position}>
-      <SheetOverlay />
+      <Show when={!local.hideOverlay}>
+        <SheetOverlay />
+      </Show>
       <SheetPrimitive.Content
         class={cn(
           sheetVariants({ position: local.position }),

--- a/apps/web/src/context/runtime.tsx
+++ b/apps/web/src/context/runtime.tsx
@@ -41,6 +41,8 @@ export interface RuntimeState {
   fps: Record<string, number>;
   split: Record<string, SliceSplitState>;
   network: RuntimeNetworkState;
+  /** Whether the touch tuning panel is open. Targets the active slice. */
+  tuningPanelOpen: boolean;
 }
 
 export type { NetworkQuality };
@@ -64,6 +66,7 @@ export const RuntimeProvider: ParentComponent = (props) => {
     fps: {},
     split: {},
     network: createInitialNetworkState(),
+    tuningPanelOpen: false,
   });
 
   const visible = createPageVisibility();


### PR DESCRIPTION
## Touch-Specific frequency input

To aid in fine-tuning on touch devices, touching the frequency in the slice flag will open a new touch-specific tuning sheet:

<img width="1536" height="2048" alt="image" src="https://github.com/user-attachments/assets/53803442-1e6d-40f3-b30d-0a7b180cf928" />
