### PR TITLE
Support the new editable filter presets

### DIFF
--- a/apps/web/src/components/settings/radio-settings.tsx
+++ b/apps/web/src/components/settings/radio-settings.tsx
@@ -1223,7 +1223,7 @@ function RadioSettingsInner(props: { radio: Radio }) {
       </Card>
 
       <Show
-        when={state.status.featureLicense.features.filter_preset_conf?.enabled}
+        when={state.status.featureLicense.features.FILTER_PRESET_CONF?.enabled}
       >
         <Card class="bg-transparent">
           <CardHeader>

--- a/apps/web/src/components/settings/radio-settings.tsx
+++ b/apps/web/src/components/settings/radio-settings.tsx
@@ -1222,127 +1222,137 @@ function RadioSettingsInner(props: { radio: Radio }) {
         </CardContent>
       </Card>
 
-      <Card class="bg-transparent">
-        <CardHeader>
-          <CardTitle>Filter Presets</CardTitle>
-        </CardHeader>
-        <CardContent class="flex flex-col gap-4">
-          <div class="flex flex-col gap-4 flex-1 min-w-0">
-            <Select
-              class="flex flex-col gap-2 select-none"
-              value={filterModeGroup()}
-              onChange={setFilterModeGroup}
-              options={Object.keys(state.status.filterPreset)}
-              itemComponent={(props) => {
-                return (
-                  <SelectItem item={props.item} class="uppercase">
-                    {props.item.rawValue.toString()}
-                  </SelectItem>
-                );
+      <Show
+        when={state.status.featureLicense.features.filter_preset_conf?.enabled}
+      >
+        <Card class="bg-transparent">
+          <CardHeader>
+            <CardTitle>Filter Presets</CardTitle>
+          </CardHeader>
+          <CardContent class="flex flex-col gap-4">
+            <div class="flex flex-col gap-4 flex-1 min-w-0">
+              <Select
+                class="flex flex-col gap-2 select-none"
+                value={filterModeGroup()}
+                onChange={setFilterModeGroup}
+                options={Object.keys(state.status.filterPreset)}
+                itemComponent={(props) => {
+                  return (
+                    <SelectItem item={props.item} class="uppercase">
+                      {props.item.rawValue.toString()}
+                    </SelectItem>
+                  );
+                }}
+              >
+                <SelectLabel>Mode Group</SelectLabel>
+                <SelectTrigger class="uppercase">
+                  <SelectValue<string>>
+                    {(state) => state.selectedOption()}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent />
+              </Select>
+              <Table class="overflow-auto shrink">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Low Hz</TableHead>
+                    <TableHead>High Hz</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <For each={filterPresets}>
+                    {(preset) => {
+                      return (
+                        <TableRow>
+                          <TableCell>
+                            <TextFieldPrimitive.Root
+                              value={preset.name}
+                              onChange={(name) => {
+                                if (name.length > 4) return;
+                                setFilterPresets(preset.index, "name", name);
+                              }}
+                            >
+                              <TextFieldPrimitive.Input size={4} class="px-1" />
+                            </TextFieldPrimitive.Root>
+                          </TableCell>
+                          <TableCell>
+                            <NumberFieldPrimitive.Root
+                              rawValue={preset.filterLowHz}
+                              onRawValueChange={(filterLowHz) =>
+                                setFilterPresets(
+                                  preset.index,
+                                  "filterLowHz",
+                                  filterLowHz,
+                                )
+                              }
+                              minValue={0}
+                              maxValue={preset.filterHighHz}
+                              format={false}
+                            >
+                              <NumberFieldPrimitive.Input
+                                size={5}
+                                class="px-1"
+                              />
+                            </NumberFieldPrimitive.Root>
+                          </TableCell>
+                          <TableCell>
+                            <NumberFieldPrimitive.Root
+                              rawValue={preset.filterHighHz}
+                              onRawValueChange={(filterHighHz) =>
+                                setFilterPresets(
+                                  preset.index,
+                                  "filterHighHz",
+                                  filterHighHz,
+                                )
+                              }
+                              minValue={preset.filterLowHz}
+                              maxValue={12_000}
+                              format={false}
+                            >
+                              <NumberFieldPrimitive.Input
+                                size={5}
+                                class="px-1"
+                              />
+                            </NumberFieldPrimitive.Root>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    }}
+                  </For>
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+          <CardFooter class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 items-stretch">
+            <Button
+              onClick={() =>
+                props.radio
+                  .filterPresets()
+                  .reset(filterModeGroup())
+                  .then(() =>
+                    setFilterPresets(
+                      state.status.filterPreset[filterModeGroup()].map((p) => ({
+                        ...p,
+                      })),
+                    ),
+                  )
+              }
+            >
+              Reset
+            </Button>
+            <Button
+              onClick={() => {
+                const ctrl = props.radio.filterPresets();
+                for (const preset of filterPresets.map((p) => ({ ...p })))
+                  ctrl.save(filterModeGroup(), preset.index, preset);
               }}
             >
-              <SelectLabel>Mode Group</SelectLabel>
-              <SelectTrigger class="uppercase">
-                <SelectValue<string>>
-                  {(state) => state.selectedOption()}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent />
-            </Select>
-            <Table class="overflow-auto shrink">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Low Hz</TableHead>
-                  <TableHead>High Hz</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <For each={filterPresets}>
-                  {(preset) => {
-                    return (
-                      <TableRow>
-                        <TableCell>
-                          <TextFieldPrimitive.Root
-                            value={preset.name}
-                            onChange={(name) => {
-                              if (name.length > 4) return;
-                              setFilterPresets(preset.index, "name", name);
-                            }}
-                          >
-                            <TextFieldPrimitive.Input size={4} class="px-1" />
-                          </TextFieldPrimitive.Root>
-                        </TableCell>
-                        <TableCell>
-                          <NumberFieldPrimitive.Root
-                            rawValue={preset.filterLowHz}
-                            onRawValueChange={(filterLowHz) =>
-                              setFilterPresets(
-                                preset.index,
-                                "filterLowHz",
-                                filterLowHz,
-                              )
-                            }
-                            minValue={0}
-                            maxValue={preset.filterHighHz}
-                            format={false}
-                          >
-                            <NumberFieldPrimitive.Input size={5} class="px-1" />
-                          </NumberFieldPrimitive.Root>
-                        </TableCell>
-                        <TableCell>
-                          <NumberFieldPrimitive.Root
-                            rawValue={preset.filterHighHz}
-                            onRawValueChange={(filterHighHz) =>
-                              setFilterPresets(
-                                preset.index,
-                                "filterHighHz",
-                                filterHighHz,
-                              )
-                            }
-                            minValue={preset.filterLowHz}
-                            maxValue={12_000}
-                            format={false}
-                          >
-                            <NumberFieldPrimitive.Input size={5} class="px-1" />
-                          </NumberFieldPrimitive.Root>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  }}
-                </For>
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-        <CardFooter class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 items-stretch">
-          <Button
-            onClick={() =>
-              props.radio
-                .filterPresets()
-                .reset(filterModeGroup())
-                .then(() =>
-                  setFilterPresets(
-                    state.status.filterPreset[filterModeGroup()].map((p) => ({
-                      ...p,
-                    })),
-                  ),
-                )
-            }
-          >
-            Reset
-          </Button>
-          <Button
-            onClick={() => {
-              const ctrl = props.radio.filterPresets();
-              for (const preset of filterPresets.map((p) => ({ ...p })))
-                ctrl.save(filterModeGroup(), preset.index, preset);
-            }}
-          >
-            Save
-          </Button>
-        </CardFooter>
-      </Card>
+              Save
+            </Button>
+          </CardFooter>
+        </Card>
+      </Show>
       <Card class="bg-transparent">
         <CardHeader>
           <CardTitle>XVTR</CardTitle>

--- a/apps/web/src/components/slice.tsx
+++ b/apps/web/src/components/slice.tsx
@@ -1,7 +1,10 @@
 import type { PolymorphicProps } from "@kobalte/core";
 import { Trigger as SelectTriggerPrimitive } from "@kobalte/core/select";
 import { ToggleButton } from "@kobalte/core/toggle-button";
-import type { SliceController } from "@repo/flexlib";
+import {
+  filterPresetModeGroupFromSliceMode,
+  type SliceController,
+} from "@repo/flexlib";
 import { createElementBounds } from "@solid-primitives/bounds";
 import { createPointerListeners } from "@solid-primitives/pointer";
 import type { Component, ComponentProps, JSX, ValidComponent } from "solid-js";
@@ -84,145 +87,6 @@ import { TxMeter } from "./ui/tx-meter";
 
 const FILTER_MAX_HZ = 12_000;
 const FILTER_MIN_HZ = -FILTER_MAX_HZ;
-
-export interface FilterPreset {
-  name: string;
-  lowCut: number;
-  highCut: number;
-}
-
-export const filterPresets: Record<string, FilterPreset[]> = {
-  AM: [
-    { name: "5.6k", lowCut: -2800, highCut: 2800 },
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-    { name: "8.0k", lowCut: -4000, highCut: 4000 },
-    { name: "10k", lowCut: -5000, highCut: 5000 },
-    { name: "12k", lowCut: -6000, highCut: 6000 },
-    { name: "14k", lowCut: -7000, highCut: 7000 },
-    { name: "16k", lowCut: -8000, highCut: 8000 },
-    { name: "20k", lowCut: -10000, highCut: 10000 },
-  ],
-  USB: [
-    { name: "1.8k", lowCut: 100, highCut: 1900 },
-    { name: "2.1k", lowCut: 100, highCut: 2200 },
-    { name: "2.4k", lowCut: 100, highCut: 2500 },
-    { name: "2.7k", lowCut: 100, highCut: 2800 },
-    { name: "2.9k", lowCut: 100, highCut: 3000 },
-    { name: "3.3k", lowCut: 100, highCut: 3400 },
-    { name: "4.0k", lowCut: 100, highCut: 4100 },
-    { name: "6.0k", lowCut: 100, highCut: 6100 },
-  ],
-  LSB: [
-    { name: "1.8k", lowCut: -1900, highCut: -100 },
-    { name: "2.1k", lowCut: -2200, highCut: -100 },
-    { name: "2.4k", lowCut: -2500, highCut: -100 },
-    { name: "2.7k", lowCut: -2800, highCut: -100 },
-    { name: "2.9k", lowCut: -3000, highCut: -100 },
-    { name: "3.3k", lowCut: -3400, highCut: -100 },
-    { name: "4.0k", lowCut: -4100, highCut: -100 },
-    { name: "6.0k", lowCut: -6100, highCut: -100 },
-  ],
-  DIGU: [
-    { name: "100", lowCut: -50, highCut: 50 },
-    { name: "300", lowCut: -150, highCut: 150 },
-    { name: "600", lowCut: -300, highCut: 300 },
-    { name: "1.0k", lowCut: -500, highCut: 500 },
-    { name: "1.5k", lowCut: -750, highCut: 750 },
-    { name: "2.0k", lowCut: -1000, highCut: 1000 },
-    { name: "3.0k", lowCut: -1500, highCut: 1500 },
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-  ],
-  DIGL: [
-    { name: "100", lowCut: -50, highCut: 50 },
-    { name: "300", lowCut: -150, highCut: 150 },
-    { name: "600", lowCut: -300, highCut: 300 },
-    { name: "1.0k", lowCut: -500, highCut: 500 },
-    { name: "1.5k", lowCut: -750, highCut: 750 },
-    { name: "2.0k", lowCut: -1000, highCut: 1000 },
-    { name: "3.0k", lowCut: -1500, highCut: 1500 },
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-  ],
-  FDVU: [
-    { name: "100", lowCut: -50, highCut: 50 },
-    { name: "300", lowCut: -150, highCut: 150 },
-    { name: "600", lowCut: -300, highCut: 300 },
-    { name: "1.0k", lowCut: -500, highCut: 500 },
-    { name: "1.5k", lowCut: -750, highCut: 750 },
-    { name: "2.0k", lowCut: -1000, highCut: 1000 },
-    { name: "3.0k", lowCut: -1500, highCut: 1500 },
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-  ],
-  FDVL: [
-    { name: "100", lowCut: -50, highCut: 50 },
-    { name: "300", lowCut: -150, highCut: 150 },
-    { name: "600", lowCut: -300, highCut: 300 },
-    { name: "1.0k", lowCut: -500, highCut: 500 },
-    { name: "1.5k", lowCut: -750, highCut: 750 },
-    { name: "2.0k", lowCut: -1000, highCut: 1000 },
-    { name: "3.0k", lowCut: -1500, highCut: 1500 },
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-  ],
-  // DIGU: [
-  //   { name: "100", lowCut: 1450, highCut: 1550 },
-  //   { name: "300", lowCut: 1350, highCut: 1650 },
-  //   { name: "600", lowCut: 1200, highCut: 1800 },
-  //   { name: "1.0k", lowCut: 1000, highCut: 2000 },
-  //   { name: "1.5k", lowCut: 750, highCut: 2250 },
-  //   { name: "2.0k", lowCut: 500, highCut: 2500 },
-  //   { name: "3.0k", lowCut: 0, highCut: 3000 },
-  //   { name: "6.0k", lowCut: 0, highCut: 6000 },
-  // ],
-  // DIGL: [
-  //   { name: "100", lowCut: -1550, highCut: -1450 },
-  //   { name: "300", lowCut: -1650, highCut: -1350 },
-  //   { name: "600", lowCut: -1800, highCut: -1200 },
-  //   { name: "1.0k", lowCut: -2000, highCut: -1000 },
-  //   { name: "1.5k", lowCut: -2250, highCut: -750 },
-  //   { name: "2.0k", lowCut: -2500, highCut: -500 },
-  //   { name: "3.0k", lowCut: -3000, highCut: 0 },
-  //   { name: "6.0k", lowCut: -6000, highCut: 0 },
-  // ],
-  RTTY: [
-    { name: "250", lowCut: -125, highCut: 125 },
-    { name: "300", lowCut: -150, highCut: 150 },
-    { name: "350", lowCut: -175, highCut: 175 },
-    { name: "400", lowCut: -200, highCut: 200 },
-    { name: "500", lowCut: -250, highCut: 250 },
-    { name: "1.0k", lowCut: -500, highCut: 500 },
-    { name: "1.5k", lowCut: -750, highCut: 750 },
-    { name: "3.0k", lowCut: -1500, highCut: 1500 },
-  ],
-  CW: [
-    { name: "50", lowCut: -25, highCut: 25 },
-    { name: "100", lowCut: -50, highCut: 50 },
-    { name: "250", lowCut: -125, highCut: 125 },
-    { name: "400", lowCut: -200, highCut: 200 },
-    { name: "500", lowCut: -250, highCut: 250 },
-    { name: "800", lowCut: -400, highCut: 400 },
-    { name: "1.0k", lowCut: -500, highCut: 500 },
-    { name: "3.0k", lowCut: -1500, highCut: 1500 },
-  ],
-  SAM: [
-    { name: "5.6k", lowCut: -2800, highCut: 2800 },
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-    { name: "8.0k", lowCut: -4000, highCut: 4000 },
-    { name: "10k", lowCut: -5000, highCut: 5000 },
-    { name: "12k", lowCut: -6000, highCut: 6000 },
-    { name: "14k", lowCut: -7000, highCut: 7000 },
-    { name: "16k", lowCut: -8000, highCut: 8000 },
-    { name: "20k", lowCut: -10000, highCut: 10000 },
-  ],
-  DFM: [
-    { name: "6.0k", lowCut: -3000, highCut: 3000 },
-    { name: "8.0k", lowCut: -4000, highCut: 4000 },
-    { name: "10k", lowCut: -5000, highCut: 5000 },
-    { name: "12k", lowCut: -6000, highCut: 6000 },
-    { name: "14k", lowCut: -7000, highCut: 7000 },
-    { name: "16k", lowCut: -8000, highCut: 8000 },
-    { name: "18k", lowCut: -9000, highCut: 9000 },
-    { name: "20k", lowCut: -10000, highCut: 10000 },
-  ],
-};
 
 export interface FmTone {
   ns: string;
@@ -405,6 +269,8 @@ export function FilterControls(props: {
   slice: SliceState;
   controller: SliceController;
 }) {
+  const { state } = useFlexRadio();
+
   const [rawDiglOffset, setRawDiglOffset] = createSignal(
     props.slice.diglOffsetHz,
   );
@@ -462,11 +328,32 @@ export function FilterControls(props: {
       ? props.controller.setFilterHigh(rawFilterHigh())
       : null;
 
-  const applyPresetOffset = (
+  const modeGroup = createMemo(() =>
+    filterPresetModeGroupFromSliceMode(props.slice.mode),
+  );
+
+  const presetEntries = createMemo(() => {
+    const group = modeGroup();
+    return group ? state.status.filterPreset[group] : undefined;
+  });
+
+  // Presets are stored canonically for USB/DIGU/FDVU; LSB/DIGL/FDVL reflect
+  // them over the slice frequency before the DIGU/DIGL carrier offset shift.
+  const mirrorForMode = (
     lowCut: number,
     highCut: number,
+    mode: string,
+  ): [number, number] =>
+    mode === "LSB" || mode === "DIGL" || mode === "FDVL"
+      ? [-highCut, -lowCut]
+      : [lowCut, highCut];
+
+  const applyPresetTransform = (
+    filterLowHz: number,
+    filterHighHz: number,
   ): [number, number] => {
     const mode = props.slice.mode;
+    const [lowCut, highCut] = mirrorForMode(filterLowHz, filterHighHz, mode);
     if (mode === "DIGU" || mode === "FDVU") {
       const offset = props.slice.diguOffsetHz;
       const clamp = Math.max(offset, -lowCut) - offset;
@@ -481,8 +368,11 @@ export function FilterControls(props: {
   };
 
   const selectedPreset = createMemo(() =>
-    filterPresets[props.slice.mode]?.find((preset) => {
-      const [low, high] = applyPresetOffset(preset.lowCut, preset.highCut);
+    presetEntries()?.find((entry) => {
+      const [low, high] = applyPresetTransform(
+        entry.filterLowHz,
+        entry.filterHighHz,
+      );
       return (
         low === props.slice.filterLowHz && high === props.slice.filterHighHz
       );
@@ -537,29 +427,28 @@ export function FilterControls(props: {
           </NumberFieldGroup>
         </NumberField>
       </Show>
-      <Show when={filterPresets[props.slice.mode]}>
-        {(presets) => (
+      <Show when={presetEntries()}>
+        {(entries) => (
           <ToggleGroup
-            value={selectedPreset()?.name}
-            onChange={(preset: string) => {
-              const presetObj = presets().find((p) => p.name === preset);
-              if (!presetObj) return;
-              const [low, high] = applyPresetOffset(
-                presetObj.lowCut,
-                presetObj.highCut,
+            value={selectedPreset()?.index.toString()}
+            onChange={(value: string) => {
+              const entry = entries().find((e) => e.index.toString() === value);
+              if (!entry) return;
+              const [low, high] = applyPresetTransform(
+                entry.filterLowHz,
+                entry.filterHighHz,
               );
               props.controller.setFilter(low, high);
             }}
-            class="grid grid-cols-4"
+            class="grid grid-cols-3"
           >
-            <For each={presets()}>
-              {(preset) => (
+            <For each={entries()}>
+              {(entry) => (
                 <ToggleGroupItem
                   variant="outline"
-                  size="sm"
-                  value={preset.name}
+                  value={entry.index.toString()}
                 >
-                  {preset.name}
+                  {entry.name}
                 </ToggleGroupItem>
               )}
             </For>

--- a/packages/flexlib/src/flex/state/filter-preset.ts
+++ b/packages/flexlib/src/flex/state/filter-preset.ts
@@ -88,6 +88,8 @@ export function filterPresetModeGroupFromSliceMode(
     case "digl":
     case "digu":
     case "fdv":
+    case "fdvu":
+    case "fdvl":
       return "digital";
     case "rtty":
       return "rtty";

--- a/packages/flexlib/src/flex/state/index.ts
+++ b/packages/flexlib/src/flex/state/index.ts
@@ -82,7 +82,10 @@ export type {
   FilterPresetModeGroup,
   FilterPresetSnapshot,
 } from "./filter-preset.js";
-export { FILTER_PRESET_COUNT } from "./filter-preset.js";
+export {
+  FILTER_PRESET_COUNT,
+  filterPresetModeGroupFromSliceMode,
+} from "./filter-preset.js";
 export type { GuiClientSnapshot } from "./gui-client.js";
 export type { MemorySnapshot } from "./memory.js";
 export type { KnownMeterUnits, MeterSnapshot, MeterUnits } from "./meter.js";


### PR DESCRIPTION
## Editable Filter Presets

<img width="304" height="227" alt="image" src="https://github.com/user-attachments/assets/186ec214-348b-46d7-a1ab-0ed5ca1a7020" />

The filter preset selection on the slice now uses the radio-led filter presets. Since the number of presets decreased from 8 to 6, the grid was adjusted to match, which in turn provides larger touch targets.

<img width="491" height="509" alt="image" src="https://github.com/user-attachments/assets/05120cf4-6553-4ea2-84ba-aa1bd5fdddf1" />

We already had the filter preset editor in the Radio Settings dialog, but now its visibility is correctly controlled by the `FILTER_PRESET_CONF` license.