### PR TITLE
Prevent clearing GUI client ID on failed connect

### DIFF
--- a/apps/web/src/context/flexradio.tsx
+++ b/apps/web/src/context/flexradio.tsx
@@ -164,7 +164,6 @@ export interface StatusState {
 export interface AppState {
   clientHandle: string | null;
   clientHandleInt: number | null;
-  clientId: string | null;
   selectedPanadapter: string | null;
   discoveredRadios: Record<string, FlexRadioDescriptor>;
   connectModal: ConnectModalState;
@@ -175,7 +174,6 @@ export const initialState = () =>
   ({
     clientHandle: null,
     clientHandleInt: null,
-    clientId: null,
     selectedPanadapter: null,
     connectModal: {
       status: ConnectionState.disconnected,
@@ -610,6 +608,18 @@ export const FlexRadioProvider: ParentComponent = (props) => {
         },
         networkMtu: preferences.networkMtu,
       });
+      setState({
+        clientHandle: radio.clientHandle,
+        clientHandleInt: radio.clientHandle
+          ? parseInt(radio.clientHandle, 16)
+          : null,
+      });
+      // Tearing down a connection clears radio.clientId. Persisting that null
+      // would make the next connect send a bare "client gui", and the radio
+      // answers that by minting a new id with an all-default settings record.
+      if (radio.clientId) {
+        setPreferences("guiClientId", radio.clientId);
+      }
     } catch (error) {
       console.error("Failed to connect to radio", error);
       showToast({
@@ -619,6 +629,7 @@ export const FlexRadioProvider: ParentComponent = (props) => {
       setState("connectModal", "status", ConnectionState.disconnected);
       setState("connectModal", "selectedRadio", null);
       setState("connectModal", "stage", ConnectionStage.TCP);
+      setState({ clientHandle: null, clientHandleInt: null });
       cleanupRadioSubscriptions();
       if (activeRadio() === radio) {
         setActiveRadio(null);
@@ -629,14 +640,6 @@ export const FlexRadioProvider: ParentComponent = (props) => {
         console.error("Error while closing failed session", closeError);
       }
     }
-    setState({
-      clientHandle: radio.clientHandle,
-      clientHandleInt: radio.clientHandle
-        ? parseInt(radio.clientHandle, 16)
-        : null,
-      clientId: radio.clientId,
-    });
-    setPreferences("guiClientId", radio.clientId);
   };
 
   onCleanup(() => {

--- a/packages/flexlib/src/flex/radio-core.ts
+++ b/packages/flexlib/src/flex/radio-core.ts
@@ -2919,6 +2919,30 @@ class RadioImpl {
       this.command(`client program ${programName}`).catch(() => {});
     }
 
+    // Register as a GUI client first, before any query or subscription, so the
+    // radio has restored this client's persisted settings by the time later
+    // commands land. TCP ordering makes the fire-and-forget below safe.
+    const isGui = info.isGui !== false; // default true
+    if (isGui) {
+      const guiClientId = info.guiClientId?.trim();
+      if (guiClientId) {
+        this._clientId = guiClientId;
+        // Restoring persistence can outrun the command timeout. A late or
+        // missing reply must not fail the connect, because aborting here
+        // leaves the radio holding a half-initialized session for this id.
+        this.command(`client gui ${guiClientId}`).catch((error) => {
+          this.logger?.warn?.("client gui registration failed", { error });
+        });
+      } else {
+        // The id-less form is the only one whose reply we need: it carries the
+        // id the radio just minted for us.
+        const response = await this.command("client gui");
+        this._clientId = response.message?.trim() || null;
+      }
+    } else if (info.boundClientId) {
+      await this.bindGuiClient(info.boundClientId);
+    }
+
     // Refresh radio info — these methods parse the replies and patch the store
     this.emitProgress("sync", "radio-info");
     await Promise.all([
@@ -2942,18 +2966,6 @@ class RadioImpl {
       () => {},
     );
     await this.command("client set send_reduced_bw_dax=1").catch(() => {});
-
-    // Register as GUI client
-    const isGui = info.isGui !== false; // default true
-    if (isGui) {
-      const guiClientId = info.guiClientId;
-      const response = await this.command(
-        guiClientId ? `client gui ${guiClientId}` : "client gui",
-      );
-      this._clientId = response.message?.trim() ?? null;
-    } else if (info.boundClientId) {
-      await this.bindGuiClient(info.boundClientId);
-    }
 
     // The radio rejects "client station" from non-GUI clients (0x500000AA)
     const stationName = info.station;


### PR DESCRIPTION
In cases where the radio was slow enough to respond to the `client gui ...` command, the connection handshake would time out and fail, causing the stored GUI client ID to be overwritten with `null`. The symptom being that after a failed connect, things that are tied to radio persistence would seem to be reset to the default (some display settings, slice/band settings, etc) because the radio sees us as a new client. The fix amounts to:

- Send the `gui client` command earlier in the connection handshake (matching the ordering of the official FlexLib)
- Don't wait for the radio to acknowledge the `gui client` command if we're sending a client ID (again matching the official FlexLib behavior)
- Never overwrite a stored GUI client ID with `null`