### PR TITLE
Better MIDI error handling

### DIFF
--- a/apps/web/src/components/settings/midi-settings.tsx
+++ b/apps/web/src/components/settings/midi-settings.tsx
@@ -30,6 +30,7 @@ import SvgSpinners180Ring from "~icons/svg-spinners/180-ring";
 import { usePreferences } from "../../context/preferences";
 import { MidiValueRing } from "../midi-value-ring";
 import { Button } from "../ui/button";
+import { Callout, CalloutContent, CalloutTitle } from "../ui/callout";
 import { Card, CardHeader, CardTitle } from "../ui/card";
 import {
   Combobox,
@@ -245,8 +246,9 @@ function behaviorOptions(
           return [
             { value: "scale-value", label: BEHAVIOR_LABELS["scale-value"] },
           ];
+        default:
+          return [] as never;
       }
-      break;
 
     case "ranged":
       switch (editorKind) {
@@ -283,7 +285,7 @@ function behaviorOptions(
       break;
   }
 
-  return [];
+  return [] as never;
 }
 
 function describeControl(mapping: MidiMapping) {
@@ -334,7 +336,10 @@ function describeBehavior(mapping: MidiMapping) {
   }
 }
 
-function AddMappingDialog(props: { class?: string | undefined }) {
+function AddMappingDialog(props: {
+  class?: string | undefined;
+  disabled?: boolean | undefined;
+}) {
   const { setPreferences } = usePreferences();
   const { inputs } = createMIDIPorts();
   const { getChoices } = useControls();
@@ -681,7 +686,7 @@ function AddMappingDialog(props: { class?: string | undefined }) {
 
   return (
     <Dialog open={open()} onOpenChange={setOpen}>
-      <DialogTrigger as={Button} class={props.class}>
+      <DialogTrigger as={Button} class={props.class} disabled={props.disabled}>
         New
       </DialogTrigger>
       <DialogContent class="translate-y-0 flex flex-col top-1/12 max-h-10/12 overflow-hidden">
@@ -1185,7 +1190,7 @@ function AddMappingDialog(props: { class?: string | undefined }) {
 
 function MidiSettingsInner() {
   const { preferences, setPreferences } = usePreferences();
-  const { inputs } = createMIDIPorts();
+  const { inputs, error: midiError } = createMIDIPorts();
   const [importFile, setImportFile] = createSignal<File>();
 
   const downloadUrl = createMemo(() => {
@@ -1213,6 +1218,14 @@ function MidiSettingsInner() {
   return (
     <>
       <div class="flex flex-col gap-4 overflow-auto shrink">
+        <Show when={midiError()}>
+          {(err) => (
+            <Callout variant="error">
+              <CalloutTitle>MIDI Error</CalloutTitle>
+              <CalloutContent>{err().message}</CalloutContent>
+            </Callout>
+          )}
+        </Show>
         <Table class="whitespace-nowrap">
           <TableHeader>
             <TableRow>
@@ -1274,7 +1287,7 @@ function MidiSettingsInner() {
             Export
           </Button>
         </div>
-        <AddMappingDialog />
+        <AddMappingDialog disabled={Boolean(midiError())} />
       </DialogFooter>
     </>
   );

--- a/apps/web/src/lib/midi/primitives.ts
+++ b/apps/web/src/lib/midi/primitives.ts
@@ -1,10 +1,12 @@
 import { ReactiveMap } from "@solid-primitives/map";
-import { type Accessor, createMemo, createSignal } from "solid-js";
+import { type Accessor, batch, createMemo, createSignal } from "solid-js";
+import { showToast } from "~/components/ui/toast";
 import { synchronizeMaps } from "../utils";
 
 const inputs = new ReactiveMap<string, MIDIInput>();
 const outputs = new ReactiveMap<string, MIDIOutput>();
 const [access, setAccess] = createSignal<MIDIAccess | undefined>();
+const [error, setError] = createSignal<Error | undefined>();
 
 let accessRequest: Promise<MIDIAccess | undefined> | undefined;
 let attachedAccess: MIDIAccess | undefined;
@@ -22,17 +24,35 @@ function ensureMIDIAccess(options?: MIDIOptions) {
   if (accessRequest || typeof navigator === "undefined") return accessRequest;
   if (!navigator.requestMIDIAccess) return;
 
-  accessRequest = navigator.requestMIDIAccess(options).then((midi) => {
-    if (attachedAccess !== midi) {
-      attachedAccess?.removeEventListener("statechange", onStateChange);
-      attachedAccess = midi;
-      midi.addEventListener("statechange", onStateChange);
-    }
-
-    setAccess(midi);
-    syncPorts(midi);
-    return midi;
-  });
+  accessRequest = navigator.requestMIDIAccess(options).then(
+    (midi) => {
+      if (attachedAccess !== midi) {
+        attachedAccess?.removeEventListener("statechange", onStateChange);
+        attachedAccess = midi;
+        midi.addEventListener("statechange", onStateChange);
+      }
+      batch(() => {
+        setError(undefined);
+        setAccess(midi);
+        syncPorts(midi);
+      });
+      return midi;
+    },
+    (error: Error) => {
+      setError(error);
+      // Chrome rejects with InvalidStateError when the platform MIDI service
+      // fails to start, which outlives any one mount. Dropping the memo lets
+      // the next caller try again instead of inheriting the failure.
+      accessRequest = undefined;
+      console.error("Error initializing MIDI support", error);
+      showToast({
+        title: "MIDI Error",
+        description: error.message,
+        variant: "error",
+      });
+      return undefined;
+    },
+  );
 
   return accessRequest;
 }
@@ -46,7 +66,7 @@ export function createMIDIAccess(
 
 export function createMIDIPorts(options?: MIDIOptions) {
   void ensureMIDIAccess(options);
-  return { inputs, outputs };
+  return { inputs, outputs, error };
 }
 
 export function createReactiveMIDIAccess(


### PR DESCRIPTION
## MIDI error handling

If MIDI initialization fails for any reason, a notification is now shown to the user:

<img width="413" height="137" alt="image" src="https://github.com/user-attachments/assets/ae3ce150-1e55-469f-a3ae-6145fc3f1c48" />

Additionally, the MIDI Controllers dialog now also includes an error message and the "New" button is disabled if MIDI could not be initialized:

<img width="553" height="349" alt="image" src="https://github.com/user-attachments/assets/823b22c7-10d4-4af3-9d92-b2b151260970" />

