### PR TITLE
Integration test suite for flexlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "test": "turbo run test",
+    "test:integration": "pnpm --filter @repo/flexlib test:integration",
     "typecheck": "turbo run typecheck",
     "release:build": "goreleaser build --snapshot --clean && rm -rf apps/server/internal/static/web",
     "release": "goreleaser release --clean && rm -rf apps/server/internal/static/web"

--- a/packages/flexlib/package.json
+++ b/packages/flexlib/package.json
@@ -58,6 +58,7 @@
     "build": "tsdown",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src tests",
     "lint:fix": "biome check --write src tests"

--- a/packages/flexlib/tests/integration/README.md
+++ b/packages/flexlib/tests/integration/README.md
@@ -1,0 +1,83 @@
+# flexlib integration tests
+
+These tests run against a **real radio**. They are completely separate from the
+unit suite: CI never runs them, `pnpm test` never picks them up, and they only
+exist to validate real radio behavior and to capture real wire traffic as
+fixture data.
+
+## Running
+
+```sh
+# from the repo root (or packages/flexlib)
+pnpm test:integration
+```
+
+Target selection:
+
+- No configuration: radios are discovered on the LAN. One radio → used
+  automatically. Several → interactive picker (TTY only).
+- `FLEX_RADIO=host[:port]` — connect directly, e.g. `FLEX_RADIO=10.0.0.5`.
+  Port defaults to 4992.
+
+Other switches:
+
+- `FLEX_ALLOW_SHARED=1` — run even when other clients are connected to the
+  radio. By default the suite refuses, because tests mutate radio-global state.
+- `FLEX_CAPTURE_GUI=1` — additionally capture a GUI-client handshake artifact.
+  Note: a GUI connect makes the radio restore per-client persistence
+  (panadapters/slices may be spawned for the test client ID).
+
+## Safety rules (non-negotiable)
+
+1. **TX inhibit is forced ON before any test runs** and held by a guard
+   connection for the entire run. The pre-existing value is restored at the
+   end. If the suite cannot confirm tx inhibit, it refuses to run. Tests must
+   NEVER cause the radio to transmit.
+2. **Leave no trace.** Any setting a test changes must be restored; anything a
+   test creates must be deleted. Delete only what you created. Global teardown
+   sweeps leaked test TNFs as a backstop, but tests should clean up themselves
+   (see `useTnfCleanup` / `removeTrackedTnfs`).
+3. GUI connections must reuse the fixed client IDs in `harness/constants.ts` —
+   the radio persists per-client-ID settings, so minting fresh IDs pollutes it.
+
+## Writing tests
+
+- Files end in `.itest.ts` (this keeps them invisible to the unit runner).
+- Everything runs sequentially — one radio, shared state, no parallelism.
+- Recon data about the target radio is available in any test file via
+  `harness/capabilities.ts`:
+
+  ```ts
+  import { hasGps, is8xxx, recon } from "./harness/capabilities.js";
+
+  describe.skipIf(!hasGps())("GPS status", () => { ... });
+  it.runIf(is8xxx())("8xxx-only behavior", () => { ... });
+  ```
+
+- Get a connection with `useSession()` (non-GUI by default). Open extra
+  connections with `connectSession()` for multiflex scenarios.
+- Commands ACK before the resulting status arrives — never assert immediately;
+  use `waitFor(...)` from `harness/session.ts`.
+
+## Ephemeral experiments
+
+Drop a `*.itest.ts` into `scratch/` (gitignored) to probe real radio behavior
+during feature development with the full harness in place. Run just that file:
+
+```sh
+pnpm test:integration scratch/my-experiment.itest.ts
+```
+
+Delete it afterwards or promote it into a real test.
+
+## Captured artifacts
+
+Every run captures the connect handshake (all TCP traffic in both directions,
+timestamped) plus raw discovery packets into `artifacts/<MODEL>_v<VERSION>/`.
+These are the main thing we want from community members: run the suite (or
+just let recon complete) against your radio and attach the artifact directory
+to an issue — radios with/without GPS, 1 vs 2 SCUs, different models and
+license states all produce usefully different handshakes.
+
+Curated captures are committed under `fixtures/` and used to ground unit-test
+fixture data in reality.

--- a/packages/flexlib/tests/integration/artifacts/.gitignore
+++ b/packages/flexlib/tests/integration/artifacts/.gitignore
@@ -1,0 +1,4 @@
+# Per-run capture output (handshake wire logs, raw discovery packets).
+# Curated captures get promoted by hand into tests/integration/fixtures/.
+*
+!.gitignore

--- a/packages/flexlib/tests/integration/global-setup.ts
+++ b/packages/flexlib/tests/integration/global-setup.ts
@@ -1,0 +1,272 @@
+import type { TestProject } from "vitest/node";
+import { FlexClient } from "../../src/flex/flex-client.js";
+import { NodeTransport } from "../../src/flex/node-transport.js";
+import type { Radio } from "../../src/flex/radio-core.js";
+import { writeHandshakeArtifact } from "./harness/artifacts.js";
+import {
+  TEST_GUI_CLIENT_ID,
+  TEST_PROGRAM,
+  TEST_STATION,
+} from "./harness/constants.js";
+import { RecordingTransport } from "./harness/recording.js";
+import { resolveTarget } from "./harness/target.js";
+import { classifySeries, type ReconInfo } from "./harness/types.js";
+
+const log = (message: string): void => {
+  process.stderr.write(`[flex-it] ${message}\n`);
+};
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(
+  probe: () => boolean,
+  description: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!probe()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await sleep(50);
+  }
+}
+
+function buildRecon(radio: Radio, originalTxInhibit: boolean): ReconInfo {
+  const snapshot = radio.snapshot();
+  if (!snapshot) throw new Error("Radio snapshot unavailable after connect");
+  const descriptor = radio.descriptor;
+  return {
+    serial: snapshot.serial || radio.serial,
+    model: snapshot.model,
+    series: classifySeries(snapshot.model),
+    nickname: snapshot.nickname,
+    callsign: snapshot.callsign,
+    version: snapshot.version,
+    radioOptions: snapshot.radioOptions,
+    scuCount: snapshot.scuCount,
+    sliceCount: snapshot.sliceCount,
+    txCount: snapshot.txCount,
+    availableSlices: snapshot.availableSlices,
+    availablePanadapters: snapshot.availablePanadapters,
+    daxIqCapacity: snapshot.daxIqCapacity,
+    atuPresent: snapshot.atuPresent,
+    gpsInstalled: snapshot.gpsInstalled,
+    oscillatorGnssPresent: snapshot.oscillatorGnssPresent,
+    oscillatorGpsdoPresent: snapshot.oscillatorGpsdoPresent,
+    oscillatorTcxoPresent: snapshot.oscillatorTcxoPresent,
+    oscillatorExternalPresent: snapshot.oscillatorExternalPresent,
+    originalTxInhibit,
+    discovery: descriptor
+      ? {
+          status: descriptor.status,
+          licensedClients: descriptor.licensedClients,
+          availableClients: descriptor.availableClients,
+          maxSlices: descriptor.maxSlices,
+          maxPanadapters: descriptor.maxPanadapters,
+          maxLicensedVersion: descriptor.maxLicensedVersion,
+          minSoftwareVersion: descriptor.minSoftwareVersion,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Recon phase. Runs once in the vitest main process before any test worker:
+ *
+ * 1. Resolve the target radio (FLEX_RADIO env or LAN discovery).
+ * 2. Refuse to run if any other client is connected (FLEX_ALLOW_SHARED=1
+ *    overrides — multiflex tests open their own extra connections instead).
+ * 3. Connect non-GUI, gather radio facts for capability-gated tests.
+ * 4. SAFETY: record the radio's tx_inhibit, force it ON, and hold this
+ *    connection open as a guard for the entire run. Teardown restores the
+ *    original value. Tests must never be able to key the transmitter.
+ * 5. Capture the real handshake wire traffic as a submittable artifact.
+ */
+export default async function setup(
+  project: TestProject,
+): Promise<() => Promise<void>> {
+  const allowShared = process.env.FLEX_ALLOW_SHARED === "1";
+
+  const transport = new RecordingTransport(new NodeTransport());
+  const client = new FlexClient({ transport });
+
+  const { target, descriptor } = await resolveTarget(client);
+  log(
+    descriptor
+      ? `target: ${descriptor.model} "${descriptor.nickname}" (${descriptor.serial}) at ${target.host}:${target.port}`
+      : `target: ${target.host}:${target.port} (no discovery packet seen)`,
+  );
+
+  const preConnectClients = descriptor?.guiClients ?? [];
+  if (preConnectClients.length > 0 && !allowShared) {
+    const list = preConnectClients
+      .map((c) => `  - ${c.program ?? "?"} @ ${c.station ?? "?"}`)
+      .join("\n");
+    throw new Error(
+      `Refusing to run: other clients are connected to the radio:\n${list}\n` +
+        `Disconnect them or set FLEX_ALLOW_SHARED=1 to override.`,
+    );
+  }
+
+  log("connecting (non-GUI recon session)...");
+  const radio = await client.connect(target, {
+    clientInfo: { program: TEST_PROGRAM, isGui: false },
+  });
+  const guardConnection = transport.connections.at(-1);
+
+  try {
+    // Status messages (transmit state among them) can trail the handshake
+    // acks; reading tx_inhibit too early would capture the store default
+    // instead of the radio's real value — and teardown would then "restore"
+    // the wrong thing. Give the subscriptions a moment to settle.
+    await sleep(1_500);
+    await waitFor(() => radio.snapshot() !== undefined, "radio snapshot");
+
+    const foreignGuiClients = radio
+      .stateSnapshot()
+      .guiClients.filter((c) => !c.isThisClient);
+    if (foreignGuiClients.length > 0 && !allowShared) {
+      const list = foreignGuiClients
+        .map((c) => `  - ${c.program ?? "?"} @ ${c.station ?? "?"} (${c.id})`)
+        .join("\n");
+      throw new Error(
+        `Refusing to run: other GUI clients are connected to the radio:\n${list}\n` +
+          `Disconnect them or set FLEX_ALLOW_SHARED=1 to override.`,
+      );
+    }
+
+    const originalTxInhibit = radio.snapshot()?.txInhibit === true;
+    log(
+      `tx inhibit on radio before suite: ${originalTxInhibit ? "ON" : "OFF"}`,
+    );
+    if (!originalTxInhibit) {
+      log("forcing tx inhibit ON for the duration of the run");
+      try {
+        await radio.setTxInhibit(true);
+      } catch (error) {
+        throw new Error(
+          `Could not enable tx inhibit — refusing to run any tests. Cause: ${String(error)}`,
+        );
+      }
+      await waitFor(
+        () => radio.snapshot()?.txInhibit === true,
+        "radio to confirm tx inhibit ON",
+      );
+    }
+
+    const recon = buildRecon(radio, originalTxInhibit);
+    log(
+      `recon: ${recon.model} v${recon.version} | SCUs=${recon.scuCount} ` +
+        `slices=${recon.sliceCount} gps=${recon.gpsInstalled ? "yes" : "no"} ` +
+        `atu=${recon.atuPresent ? "yes" : "no"} options="${recon.radioOptions}"`,
+    );
+
+    if (guardConnection) {
+      const file = writeHandshakeArtifact({
+        recon,
+        descriptor,
+        connection: guardConnection,
+        transport,
+        kind: "nongui",
+      });
+      log(`handshake artifact written: ${file}`);
+    }
+
+    if (process.env.FLEX_CAPTURE_GUI === "1") {
+      log("FLEX_CAPTURE_GUI=1: capturing GUI-client handshake...");
+      const guiTransport = new RecordingTransport(new NodeTransport());
+      const guiClient = new FlexClient({ transport: guiTransport });
+      try {
+        const guiRadio = await guiClient.connect(target, {
+          clientInfo: {
+            program: TEST_PROGRAM,
+            isGui: true,
+            guiClientId: TEST_GUI_CLIENT_ID,
+            station: TEST_STATION,
+          },
+        });
+        await sleep(1_500);
+        const guiConnection = guiTransport.connections.at(-1);
+        if (guiConnection) {
+          const file = writeHandshakeArtifact({
+            recon,
+            descriptor,
+            connection: guiConnection,
+            transport: guiTransport,
+            kind: "gui",
+          });
+          log(`GUI handshake artifact written: ${file}`);
+        }
+        await guiRadio.disconnect();
+      } finally {
+        await guiClient.close().catch(() => {});
+      }
+      // The GUI connect may have restored per-client persistence that
+      // touches transmit settings — re-assert the guard.
+      if (radio.snapshot()?.txInhibit !== true) {
+        log("tx inhibit dropped after GUI capture — re-forcing");
+        await radio.setTxInhibit(true);
+        await waitFor(
+          () => radio.snapshot()?.txInhibit === true,
+          "radio to confirm tx inhibit ON",
+        );
+      }
+    }
+
+    const baselineTnfIds = new Set(radio.tnfs().map((tnf) => tnf.id));
+
+    project.provide("flex:target", target);
+    project.provide("flex:recon", recon);
+
+    // Teardown: leave the radio exactly as we found it.
+    return async () => {
+      try {
+        if (radio.connectionState === "connected") {
+          if (radio.snapshot()?.txInhibit !== true) {
+            log(
+              "WARNING: tx inhibit was OFF at teardown — a test or another client changed it",
+            );
+          }
+
+          // Sweep TNFs leaked by tests. Only safe when we know no other
+          // client has been creating TNFs concurrently.
+          if (!allowShared) {
+            const leaked = radio
+              .tnfs()
+              .filter((tnf) => !baselineTnfIds.has(tnf.id));
+            for (const tnf of leaked) {
+              log(`removing leaked test TNF ${tnf.id}`);
+              await tnf.remove().catch(() => {});
+            }
+          }
+
+          if (!originalTxInhibit) {
+            log("restoring tx inhibit to OFF (its pre-suite value)");
+            await radio.setTxInhibit(false).catch((error) => {
+              log(`WARNING: failed to restore tx inhibit: ${String(error)}`);
+            });
+            await waitFor(
+              () => radio.snapshot()?.txInhibit === false,
+              "radio to confirm tx inhibit restore",
+            ).catch(() => {});
+          } else {
+            log("tx inhibit was ON before the suite — leaving it ON");
+          }
+        } else {
+          log(
+            "WARNING: guard connection lost during run — cannot verify/restore radio state",
+          );
+        }
+      } finally {
+        await radio.disconnect().catch(() => {});
+        await client.close().catch(() => {});
+      }
+    };
+  } catch (error) {
+    await radio.disconnect().catch(() => {});
+    await client.close().catch(() => {});
+    throw error;
+  }
+}

--- a/packages/flexlib/tests/integration/harness/artifacts.ts
+++ b/packages/flexlib/tests/integration/harness/artifacts.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { FlexRadioDescriptor } from "../../../src/flex/adapters.js";
+import type { RecordingConnection, RecordingTransport } from "./recording.js";
+import type { ReconInfo } from "./types.js";
+
+const ARTIFACTS_DIR = join(import.meta.dirname, "..", "artifacts");
+
+/**
+ * Write a captured handshake (and any discovery packets) as a submittable
+ * artifact. Layout:
+ *
+ *   tests/integration/artifacts/<MODEL>_v<VERSION>/
+ *     handshake.<gui|nongui>.json
+ *     discovery.<n>.bin
+ *
+ * Curated copies get promoted by hand into tests/integration/fixtures/.
+ */
+export function writeHandshakeArtifact(options: {
+  readonly recon: ReconInfo;
+  readonly descriptor: FlexRadioDescriptor | undefined;
+  readonly connection: RecordingConnection;
+  readonly transport: RecordingTransport;
+  readonly kind: "gui" | "nongui";
+}): string {
+  const { recon, descriptor, connection, transport, kind } = options;
+  const version = recon.version.split("+")[0] || recon.version || "unknown";
+  const dir = join(ARTIFACTS_DIR, `${recon.model || "UNKNOWN"}_v${version}`);
+  mkdirSync(dir, { recursive: true });
+
+  const artifact = {
+    capturedAt: new Date().toISOString(),
+    kind,
+    radio: recon,
+    discovery: descriptor ?? null,
+    wire: connection.records,
+  };
+  const file = join(dir, `handshake.${kind}.json`);
+  writeFileSync(file, `${JSON.stringify(artifact, null, 2)}\n`);
+
+  // Raw discovery packets, deduped byte-for-byte, for VITA parser fixtures.
+  const seen = new Set<string>();
+  let index = 0;
+  for (const packet of transport.discoveryPackets) {
+    const key = Buffer.from(packet).toString("base64");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    writeFileSync(join(dir, `discovery.${index}.bin`), packet);
+    index += 1;
+  }
+
+  return file;
+}

--- a/packages/flexlib/tests/integration/harness/capabilities.ts
+++ b/packages/flexlib/tests/integration/harness/capabilities.ts
@@ -1,0 +1,25 @@
+import { inject } from "vitest";
+import type { ReconInfo } from "./types.js";
+
+/**
+ * Capability accessors for gating tests on what the target radio supports.
+ *
+ * Usable at test-file top level (recon runs in global setup, before any
+ * worker starts):
+ *
+ * ```ts
+ * describe.skipIf(!hasGps())("GPS status", () => { ... });
+ * it.runIf(is8xxx())("8xxx-only behavior", () => { ... });
+ * ```
+ */
+export function recon(): ReconInfo {
+  return inject("flex:recon");
+}
+
+export const is6xxx = (): boolean => recon().series === "6xxx";
+export const is8xxx = (): boolean => recon().series === "8xxx";
+export const isAurora = (): boolean => recon().series === "aurora";
+export const hasGps = (): boolean => recon().gpsInstalled;
+export const hasAtu = (): boolean => recon().atuPresent;
+export const hasMultipleScus = (): boolean => recon().scuCount > 1;
+export const hasGnssOscillator = (): boolean => recon().oscillatorGnssPresent;

--- a/packages/flexlib/tests/integration/harness/constants.ts
+++ b/packages/flexlib/tests/integration/harness/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * Fixed identities used by the integration suite.
+ *
+ * GUI client IDs are persisted by the radio (it keys per-client settings on
+ * them), so tests must NOT let the radio mint a fresh ID every session — that
+ * would litter the radio with abandoned client records. Every GUI connection
+ * made by this suite reuses one of these fixed IDs.
+ */
+
+/** Program name announced to the radio by every suite connection. */
+export const TEST_PROGRAM = "SolidSDR-IT";
+
+/** Station name announced by GUI connections. */
+export const TEST_STATION = "SolidSDR-IT";
+
+/** Primary GUI client ID for tests that need a GUI connection. */
+export const TEST_GUI_CLIENT_ID = "5011d5d0-7e57-4000-8000-000000000001";
+
+/** Secondary GUI client ID for multiflex tests (second simultaneous GUI). */
+export const TEST_GUI_CLIENT_ID_2 = "5011d5d0-7e57-4000-8000-000000000002";
+
+/** Tertiary GUI client ID, reserved for future multiflex scenarios. */
+export const TEST_GUI_CLIENT_ID_3 = "5011d5d0-7e57-4000-8000-000000000003";
+
+/** Default FlexRadio TCP command port. */
+export const DEFAULT_RADIO_PORT = 4992;

--- a/packages/flexlib/tests/integration/harness/recording.ts
+++ b/packages/flexlib/tests/integration/harness/recording.ts
@@ -1,0 +1,133 @@
+import type {
+  FileDownloadReceiver,
+  FlexConnection,
+  FlexConnectionEvents,
+  FlexTransport,
+  FlexTransportEvents,
+  RadioEndpoint,
+} from "../../../src/flex/transport.js";
+import type { Subscription } from "../../../src/util/events.js";
+
+/** One captured TCP payload. `t` is ms since the recording started. */
+export interface WireRecord {
+  readonly dir: "tx" | "rx";
+  readonly t: number;
+  readonly data: string;
+}
+
+const decoder = new TextDecoder();
+
+/**
+ * FlexConnection decorator that records every TCP payload in both directions.
+ * Used to capture real handshakes and wire traffic as test fixtures.
+ */
+export class RecordingConnection implements FlexConnection {
+  readonly records: WireRecord[] = [];
+  private readonly startedAt = Date.now();
+
+  constructor(private readonly inner: FlexConnection) {}
+
+  private record(dir: "tx" | "rx", data: string | Uint8Array): void {
+    this.records.push({
+      dir,
+      t: Date.now() - this.startedAt,
+      data: typeof data === "string" ? data : decoder.decode(data),
+    });
+  }
+
+  on<K extends keyof FlexConnectionEvents>(
+    event: K,
+    handler: (payload: FlexConnectionEvents[K]) => void,
+  ): Subscription {
+    if (event === "tcpData") {
+      return this.inner.on("tcpData", (data) => {
+        this.record("rx", data);
+        (handler as (payload: FlexConnectionEvents["tcpData"]) => void)(data);
+      });
+    }
+    return this.inner.on(event, handler);
+  }
+
+  once<K extends keyof FlexConnectionEvents>(
+    event: K,
+    handler: (payload: FlexConnectionEvents[K]) => void,
+  ): Subscription {
+    return this.inner.once(event, handler);
+  }
+
+  connectTcp(endpoint: RadioEndpoint): Promise<void> {
+    return this.inner.connectTcp(endpoint);
+  }
+
+  connectUdp(endpoint: RadioEndpoint): Promise<void> {
+    return this.inner.connectUdp(endpoint);
+  }
+
+  sendTcp(data: string): Promise<void> {
+    this.record("tx", data);
+    return this.inner.sendTcp(data);
+  }
+
+  sendUdp(data: Uint8Array): Promise<void> {
+    return this.inner.sendUdp(data);
+  }
+
+  openUpload(
+    endpoint: RadioEndpoint,
+    data: AsyncIterable<Uint8Array>,
+  ): Promise<void> {
+    return this.inner.openUpload(endpoint, data);
+  }
+
+  prepareDownload(endpoint: RadioEndpoint): Promise<FileDownloadReceiver> {
+    return this.inner.prepareDownload(endpoint);
+  }
+
+  close(): Promise<void> {
+    return this.inner.close();
+  }
+}
+
+/**
+ * FlexTransport decorator that wraps every created connection in a
+ * {@link RecordingConnection} and keeps raw discovery packets.
+ */
+export class RecordingTransport implements FlexTransport {
+  readonly connections: RecordingConnection[] = [];
+  /** Raw VITA discovery packets seen while discovery was running. */
+  readonly discoveryPackets: Uint8Array[] = [];
+
+  constructor(private readonly inner: FlexTransport) {
+    this.inner.on("discoveryData", (packet) => {
+      // Keep a bounded set; dedupe is done at artifact-write time.
+      if (this.discoveryPackets.length < 64) {
+        this.discoveryPackets.push(packet.slice());
+      }
+    });
+  }
+
+  on<K extends keyof FlexTransportEvents>(
+    event: K,
+    handler: (payload: FlexTransportEvents[K]) => void,
+  ): Subscription {
+    return this.inner.on(event, handler);
+  }
+
+  startDiscovery(): Promise<void> {
+    return this.inner.startDiscovery();
+  }
+
+  stopDiscovery(): Promise<void> {
+    return this.inner.stopDiscovery();
+  }
+
+  createConnection(): FlexConnection {
+    const conn = new RecordingConnection(this.inner.createConnection());
+    this.connections.push(conn);
+    return conn;
+  }
+
+  close(): Promise<void> {
+    return this.inner.close();
+  }
+}

--- a/packages/flexlib/tests/integration/harness/session.ts
+++ b/packages/flexlib/tests/integration/harness/session.ts
@@ -1,0 +1,200 @@
+import { afterAll, afterEach, beforeAll, inject } from "vitest";
+import { FlexClient } from "../../../src/flex/flex-client.js";
+import { NodeTransport } from "../../../src/flex/node-transport.js";
+import type { Radio } from "../../../src/flex/radio-core.js";
+import type { TnfController } from "../../../src/flex/tnf.js";
+import { TEST_PROGRAM, TEST_STATION } from "./constants.js";
+
+export interface SessionOptions {
+  /** Connect as a GUI client. Default false — non-GUI minimizes radio-side effects. */
+  readonly gui?: boolean;
+  /**
+   * Fixed GUI client ID to reuse (required when `gui` is true — never let the
+   * radio mint a fresh ID; it persists them). Use the TEST_GUI_CLIENT_ID*
+   * constants.
+   */
+  readonly guiClientId?: string;
+}
+
+export interface TestSession {
+  readonly client: FlexClient;
+  readonly radio: Radio;
+  dispose(): Promise<void>;
+}
+
+/**
+ * Open a connection to the target radio (resolved during recon).
+ *
+ * SAFETY: after every connect, tx inhibit is re-verified and re-forced if
+ * anything (e.g. GUI client persistence restore) turned it back off. Tests
+ * must never run without it.
+ */
+export async function connectSession(
+  options: SessionOptions = {},
+): Promise<TestSession> {
+  const target = inject("flex:target");
+  const gui = options.gui === true;
+  if (gui && !options.guiClientId) {
+    throw new Error(
+      "GUI sessions must reuse a fixed client ID (TEST_GUI_CLIENT_ID*)",
+    );
+  }
+
+  const client = new FlexClient({ transport: new NodeTransport() });
+  let radio: Radio;
+  try {
+    radio = await client.connect(target, {
+      clientInfo: {
+        program: TEST_PROGRAM,
+        isGui: gui,
+        guiClientId: gui ? options.guiClientId : undefined,
+        station: gui ? TEST_STATION : undefined,
+      },
+    });
+  } catch (error) {
+    await client.close().catch(() => {});
+    throw error;
+  }
+
+  const session: TestSession = {
+    client,
+    radio,
+    async dispose() {
+      await radio.disconnect().catch(() => {});
+      await client.close().catch(() => {});
+    },
+  };
+
+  try {
+    await ensureTxInhibit(radio);
+  } catch (error) {
+    await session.dispose();
+    throw error;
+  }
+
+  return session;
+}
+
+/** Force tx inhibit on and wait until the radio confirms it. */
+export async function ensureTxInhibit(radio: Radio): Promise<void> {
+  if (radio.snapshot()?.txInhibit === true) return;
+  console.warn("[flex-it] tx inhibit was OFF after connect — re-forcing it on");
+  await radio.setTxInhibit(true);
+  await waitFor(
+    () => radio.snapshot()?.txInhibit === true,
+    "radio to confirm tx inhibit on",
+  );
+}
+
+/**
+ * Shared per-file session. Registers beforeAll/afterAll; call the returned
+ * accessors inside tests only.
+ */
+export function useSession(options: SessionOptions = {}): {
+  radio: () => Radio;
+  session: () => TestSession;
+} {
+  let current: TestSession | undefined;
+
+  beforeAll(async () => {
+    current = await connectSession(options);
+  });
+
+  afterAll(async () => {
+    await current?.dispose();
+    current = undefined;
+  });
+
+  const session = (): TestSession => {
+    if (!current) throw new Error("Session not connected (outside test run?)");
+    return current;
+  };
+
+  return { session, radio: () => session().radio };
+}
+
+// ---------------------------------------------------------------------------
+// Waiting
+// ---------------------------------------------------------------------------
+
+export interface WaitForOptions {
+  readonly timeoutMs?: number;
+  readonly intervalMs?: number;
+}
+
+/**
+ * Poll until `probe` returns a truthy value, then return it.
+ *
+ * Radio commands often ACK before the resulting status message arrives, so
+ * asserting on state right after a command is a race — always wait for the
+ * state to actually reflect the change.
+ */
+export async function waitFor<T>(
+  probe: () => T | undefined | null | false,
+  description: string,
+  options: WaitForOptions = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const intervalMs = options.intervalMs ?? 50;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = probe();
+    if (value) return value;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for ${description}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TNF helpers — create is async on the wire (the new TNF arrives via a
+// later status message), and cleanup must only ever touch TNFs we created.
+// ---------------------------------------------------------------------------
+
+const trackedTnfIds = new Set<string>();
+
+/**
+ * Create a TNF and wait for it to appear in local state. The TNF is tracked;
+ * call {@link removeTrackedTnfs} in afterEach to guarantee cleanup.
+ */
+export async function createTnfAndWait(
+  radio: Radio,
+  frequencyMHz: number,
+  options: WaitForOptions = {},
+): Promise<TnfController> {
+  const before = new Set(radio.tnfs().map((tnf) => tnf.id));
+  await radio.createTnf(frequencyMHz);
+  const created = await waitFor(
+    () => radio.tnfs().find((tnf) => !before.has(tnf.id)),
+    `TNF at ${frequencyMHz} MHz to appear in state`,
+    options,
+  );
+  trackedTnfIds.add(created.id);
+  return created;
+}
+
+/** Stop tracking a TNF the test already removed itself. */
+export function untrackTnf(id: string): void {
+  trackedTnfIds.delete(id);
+}
+
+/** Remove every TNF created via {@link createTnfAndWait} that still exists. */
+export async function removeTrackedTnfs(radio: Radio): Promise<void> {
+  const ids = Array.from(trackedTnfIds);
+  trackedTnfIds.clear();
+  for (const id of ids) {
+    const controller = radio.tnf(id);
+    if (!controller) continue;
+    await controller.remove().catch(() => {});
+  }
+}
+
+/** Register an afterEach hook that sweeps tracked TNFs. */
+export function useTnfCleanup(radio: () => Radio): void {
+  afterEach(async () => {
+    await removeTrackedTnfs(radio());
+  });
+}

--- a/packages/flexlib/tests/integration/harness/target.ts
+++ b/packages/flexlib/tests/integration/harness/target.ts
@@ -1,0 +1,113 @@
+import { createInterface } from "node:readline/promises";
+import type { FlexRadioDescriptor } from "../../../src/flex/adapters.js";
+import type { FlexClient } from "../../../src/flex/flex-client.js";
+import { DEFAULT_RADIO_PORT } from "./constants.js";
+import type { RadioTarget } from "./types.js";
+
+const DISCOVERY_WINDOW_MS = 3_500;
+
+export interface ResolvedTarget {
+  readonly target: RadioTarget;
+  readonly descriptor?: FlexRadioDescriptor;
+}
+
+/** Parse `host[:port]` from the FLEX_RADIO env var. */
+function parseEnvTarget(raw: string): RadioTarget {
+  const [host, portRaw] = raw.split(":");
+  if (!host) throw new Error(`FLEX_RADIO is set but empty: "${raw}"`);
+  const port = portRaw ? Number.parseInt(portRaw, 10) : DEFAULT_RADIO_PORT;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`FLEX_RADIO has an invalid port: "${raw}"`);
+  }
+  return { host, port };
+}
+
+function describeRadio(d: FlexRadioDescriptor): string {
+  return `${d.model} "${d.nickname}" (${d.serial}) at ${d.host}:${d.port} — ${d.status}`;
+}
+
+async function discoverRadios(
+  client: FlexClient,
+  windowMs: number,
+): Promise<FlexRadioDescriptor[]> {
+  await client.startDiscovery();
+  try {
+    await new Promise((resolve) => setTimeout(resolve, windowMs));
+  } finally {
+    await client.stopDiscovery();
+  }
+  return client
+    .radios()
+    .map((radio) => radio.descriptor)
+    .filter((d): d is FlexRadioDescriptor => d !== undefined);
+}
+
+async function promptForRadio(
+  radios: FlexRadioDescriptor[],
+): Promise<FlexRadioDescriptor> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    process.stderr.write("Multiple radios discovered:\n");
+    radios.forEach((d, i) => {
+      process.stderr.write(`  [${i + 1}] ${describeRadio(d)}\n`);
+    });
+    for (;;) {
+      const answer = await rl.question(
+        `Select radio to test against [1-${radios.length}]: `,
+      );
+      const index = Number.parseInt(answer.trim(), 10) - 1;
+      const chosen = radios[index];
+      if (chosen) return chosen;
+      process.stderr.write("Invalid selection.\n");
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Determine which radio the suite runs against.
+ *
+ * - `FLEX_RADIO=host[:port]` connects directly. Discovery still runs briefly
+ *   so we can attach the radio's discovery metadata to recon/artifacts, but
+ *   finding nothing is not an error (the radio may be on another subnet).
+ * - Otherwise radios are discovered on the LAN. Exactly one → use it.
+ *   Several → interactive prompt when stdin is a TTY, abort otherwise.
+ */
+export async function resolveTarget(
+  client: FlexClient,
+): Promise<ResolvedTarget> {
+  const env = process.env.FLEX_RADIO?.trim();
+  if (env) {
+    const target = parseEnvTarget(env);
+    const radios = await discoverRadios(client, 1_500).catch(() => []);
+    const descriptor = radios.find((d) => d.host === target.host);
+    return { target, descriptor };
+  }
+
+  const radios = await discoverRadios(client, DISCOVERY_WINDOW_MS);
+  if (radios.length === 0) {
+    throw new Error(
+      "No radios discovered on the network. " +
+        "Set FLEX_RADIO=host[:port] to connect directly.",
+    );
+  }
+
+  let chosen: FlexRadioDescriptor;
+  if (radios.length === 1) {
+    chosen = radios[0];
+  } else if (process.stdin.isTTY) {
+    chosen = await promptForRadio(radios);
+  } else {
+    const list = radios.map((d) => `  - ${describeRadio(d)}`).join("\n");
+    throw new Error(
+      `Multiple radios discovered and stdin is not a TTY. ` +
+        `Set FLEX_RADIO=host[:port] to pick one:\n${list}`,
+    );
+  }
+
+  return {
+    target: { host: chosen.host, port: chosen.port },
+    descriptor: chosen,
+  };
+}

--- a/packages/flexlib/tests/integration/harness/types.ts
+++ b/packages/flexlib/tests/integration/harness/types.ts
@@ -1,0 +1,64 @@
+/** Radio model family, derived from the model string during recon. */
+export type RadioSeries = "6xxx" | "8xxx" | "aurora" | "other";
+
+/** Endpoint of the radio the suite is running against. */
+export interface RadioTarget {
+  readonly host: string;
+  readonly port: number;
+}
+
+/**
+ * Facts gathered about the target radio during the recon phase
+ * (global setup). Serializable — travels from the vitest main process
+ * to test workers via provide/inject.
+ *
+ * Tests use these to gate model/option-specific cases via `skipIf`.
+ */
+export interface ReconInfo {
+  readonly serial: string;
+  readonly model: string;
+  readonly series: RadioSeries;
+  readonly nickname: string;
+  readonly callsign: string;
+  readonly version: string;
+  /** Raw options string reported by the radio (installed options/licenses). */
+  readonly radioOptions: string;
+  readonly scuCount: number;
+  readonly sliceCount: number;
+  readonly txCount: number;
+  readonly availableSlices: number;
+  readonly availablePanadapters: number;
+  readonly daxIqCapacity: number;
+  readonly atuPresent: boolean;
+  readonly gpsInstalled: boolean;
+  readonly oscillatorGnssPresent: boolean;
+  readonly oscillatorGpsdoPresent: boolean;
+  readonly oscillatorTcxoPresent: boolean;
+  readonly oscillatorExternalPresent: boolean;
+  /** tx_inhibit value found on the radio BEFORE the suite forced it on. */
+  readonly originalTxInhibit: boolean;
+  /** Discovery metadata, when a discovery packet was seen for this radio. */
+  readonly discovery?: {
+    readonly status: string;
+    readonly licensedClients: number;
+    readonly availableClients: number;
+    readonly maxSlices: number;
+    readonly maxPanadapters: number;
+    readonly maxLicensedVersion: string;
+    readonly minSoftwareVersion: string;
+  };
+}
+
+export function classifySeries(model: string): RadioSeries {
+  if (model.startsWith("FLEX-6")) return "6xxx";
+  if (model.startsWith("FLEX-8")) return "8xxx";
+  if (model.startsWith("AU-")) return "aurora";
+  return "other";
+}
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    "flex:target": RadioTarget;
+    "flex:recon": ReconInfo;
+  }
+}

--- a/packages/flexlib/tests/integration/recon.itest.ts
+++ b/packages/flexlib/tests/integration/recon.itest.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { hasGps, recon } from "./harness/capabilities.js";
+import { useSession } from "./harness/session.js";
+
+describe("connection handshake", () => {
+  const { radio } = useSession();
+
+  it("connects and receives a client handle", () => {
+    expect(radio().connectionState).toBe("connected");
+    expect(radio().clientHandle).toBeTruthy();
+  });
+
+  it("populates the radio snapshot with identity matching recon", () => {
+    const snapshot = radio().snapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.model).toBe(recon().model);
+    expect(snapshot?.version).toBe(recon().version);
+    expect(snapshot?.serial).toBe(recon().serial);
+  });
+
+  it("runs with the tx inhibit guard engaged", () => {
+    // The suite's cardinal safety rule: tests never run without tx inhibit.
+    expect(radio().snapshot()?.txInhibit).toBe(true);
+  });
+
+  it("reports plausible hardware facts", () => {
+    const snapshot = radio().snapshot();
+    expect(snapshot?.scuCount).toBeGreaterThan(0);
+    expect(snapshot?.sliceCount).toBeGreaterThan(0);
+    expect(snapshot?.rxAntennaList.length).toBeGreaterThan(0);
+  });
+
+  describe.skipIf(!hasGps())("GPS-equipped radios", () => {
+    it("reports gpsInstalled in the snapshot", () => {
+      expect(radio().snapshot()?.gpsInstalled).toBe(true);
+    });
+  });
+});

--- a/packages/flexlib/tests/integration/scratch/.gitignore
+++ b/packages/flexlib/tests/integration/scratch/.gitignore
@@ -1,0 +1,6 @@
+# Ephemeral experiment tests — never committed. Drop a *.itest.ts here to run
+# one-off experiments against the radio with the full harness (recon,
+# tx-inhibit guard, cleanup helpers), then delete it or promote it to a real
+# test next to the others.
+*
+!.gitignore

--- a/packages/flexlib/tests/integration/tnf.itest.ts
+++ b/packages/flexlib/tests/integration/tnf.itest.ts
@@ -1,0 +1,141 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  connectSession,
+  createTnfAndWait,
+  removeTrackedTnfs,
+  type TestSession,
+  untrackTnf,
+  useSession,
+  waitFor,
+} from "./harness/session.js";
+
+// Arbitrary quiet frequencies well inside ham bands. TNFs are receive-side
+// notches; frequency choice has no RF-emission implications.
+const FREQ_A_MHZ = 28.123456;
+const FREQ_B_MHZ = 21.234567;
+
+describe("TNF lifecycle", () => {
+  const { radio } = useSession();
+
+  afterEach(async () => {
+    await removeTrackedTnfs(radio());
+  });
+
+  it("tnf create makes a TNF appear via status with the requested frequency", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+    expect(tnf.frequencyMHz).toBeCloseTo(FREQ_A_MHZ, 6);
+  });
+
+  it("a freshly created TNF has the radio's real defaults", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+    const snapshot = tnf.snapshot();
+    // Grounding data for unit-test fixtures: what a real radio reports for a
+    // brand-new TNF (contrived unit fixtures should match this shape).
+    expect(snapshot.permanent).toBe(false);
+    expect(snapshot.depth).toBeGreaterThanOrEqual(1);
+    expect(snapshot.depth).toBeLessThanOrEqual(3);
+    expect(snapshot.bandwidthMHz).toBeGreaterThan(0);
+  });
+
+  it("tnf set updates frequency, depth, width, and permanent", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+
+    await tnf.setFrequency(FREQ_B_MHZ);
+    await tnf.setDepth(2);
+    await tnf.setBandwidth(0.0002);
+    await tnf.setPermanent(true);
+
+    // Local state is patched optimistically; these assertions confirm the
+    // radio accepted the commands (rejections would have thrown above) and
+    // that local state holds the expected values.
+    const snapshot = tnf.snapshot();
+    expect(snapshot.frequencyMHz).toBeCloseTo(FREQ_B_MHZ, 6);
+    expect(snapshot.depth).toBe(2);
+    expect(snapshot.bandwidthMHz).toBeCloseTo(0.0002, 6);
+    expect(snapshot.permanent).toBe(true);
+
+    // Never leave a permanent TNF behind.
+    await tnf.setPermanent(false);
+  });
+
+  it("tnf remove deletes the TNF from state", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+    const id = tnf.id;
+
+    await tnf.remove();
+    untrackTnf(id);
+
+    await waitFor(
+      () =>
+        radio()
+          .tnfs()
+          .every((t) => t.id !== id),
+      `TNF ${id} to disappear from state`,
+    );
+  });
+});
+
+describe("TNF multi-client visibility", () => {
+  // TNFs are radio-global. Changes made by one client must be observed by
+  // another client purely via status messages — the observer session has no
+  // optimistic patches, so its state is ground truth for what the radio sent.
+  const { radio } = useSession();
+  let observer: TestSession | undefined;
+
+  beforeAll(async () => {
+    observer = await connectSession();
+  });
+
+  afterAll(async () => {
+    await observer?.dispose();
+  });
+
+  afterEach(async () => {
+    await removeTrackedTnfs(radio());
+  });
+
+  it("a TNF created by one client is announced to another", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+
+    const remote = await waitFor(
+      () => observer?.radio.tnf(tnf.id),
+      `TNF ${tnf.id} to appear on the observer connection`,
+    );
+    expect(remote.frequencyMHz).toBeCloseTo(FREQ_A_MHZ, 6);
+  });
+
+  it("tnf set changes propagate to the other client", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+    await waitFor(
+      () => observer?.radio.tnf(tnf.id),
+      `TNF ${tnf.id} to appear on the observer connection`,
+    );
+
+    await tnf.setFrequency(FREQ_B_MHZ);
+
+    await waitFor(() => {
+      const remote = observer?.radio.tnf(tnf.id);
+      return (
+        remote !== undefined &&
+        Math.abs(remote.frequencyMHz - FREQ_B_MHZ) < 1e-6
+      );
+    }, `observer to see TNF ${tnf.id} move to ${FREQ_B_MHZ} MHz`);
+  });
+
+  it("tnf remove propagates to the other client", async () => {
+    const tnf = await createTnfAndWait(radio(), FREQ_A_MHZ);
+    const id = tnf.id;
+    await waitFor(
+      () => observer?.radio.tnf(id),
+      `TNF ${id} to appear on the observer connection`,
+    );
+
+    await tnf.remove();
+    untrackTnf(id);
+
+    await waitFor(
+      () => observer?.radio.tnfs().every((t) => t.id !== id) === true,
+      `observer to see TNF ${id} removed`,
+    );
+  });
+});

--- a/packages/flexlib/vitest.config.ts
+++ b/packages/flexlib/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Unit tests only. Integration tests (tests/integration/**/*.itest.ts) run
+// against a real radio and have their own config: vitest.integration.config.ts.
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    exclude: ["tests/integration/**"],
+  },
+});

--- a/packages/flexlib/vitest.integration.config.ts
+++ b/packages/flexlib/vitest.integration.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Integration test config — runs against a REAL radio.
+ *
+ * Never wired into `pnpm test` or CI. Run with `pnpm test:integration`.
+ *
+ * Target selection (see tests/integration/harness/target.ts):
+ *   FLEX_RADIO=host[:port]   connect directly, skip discovery
+ *   (unset)                  discover radios; prompts if more than one is found
+ *
+ * Other env switches:
+ *   FLEX_ALLOW_SHARED=1      run even when other clients are connected
+ *   FLEX_CAPTURE_GUI=1       also capture a GUI-client handshake artifact
+ */
+export default defineConfig({
+  test: {
+    include: ["tests/integration/**/*.itest.ts"],
+    globalSetup: ["tests/integration/global-setup.ts"],
+    // One radio, shared global state (TNFs, tx inhibit): everything runs
+    // strictly sequentially.
+    fileParallelism: false,
+    maxConcurrency: 1,
+    sequence: { concurrent: false },
+    testTimeout: 20_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
# Integration test suite for flexlib

Adds a real-radio integration testbed, fully separate from the unit suite and CI.

## Usage

```sh
pnpm test:integration                       # discovers radios on the LAN
FLEX_RADIO=10.0.0.5 pnpm test:integration   # or connect directly
```

## How it works

- Integration tests use a `.itest.ts` extension and their own `vitest.integration.config.ts`, so `pnpm test` and CI can never pick them up.
- A recon phase (vitest `globalSetup`) resolves the target radio, connects non-GUI, and shares radio facts (model, SCUs, GPS, options) with tests via `provide`/`inject`. Tests gate on capabilities with `describe.skipIf(!hasGps())`, `it.runIf(is8xxx())`, etc.
- Refuses to run if other clients are connected (`FLEX_ALLOW_SHARED=1` overrides). Everything runs sequentially against one radio.

## Safety

- TX inhibit is recorded, forced on before any test runs, held by a guard connection for the entire run, and restored to its original value at teardown. If inhibit cannot be confirmed, nothing runs.
- Tests only delete what they create. TNF helpers track created TNFs and global teardown sweeps leaks as a backstop.
- GUI connections must reuse fixed client IDs from `harness/constants.ts` so the radio never accumulates abandoned per-client records.

## Fixture capture

Every run records the full connect handshake (timestamped bidirectional TCP) plus raw discovery packets to `tests/integration/artifacts/<MODEL>_v<VERSION>/`. Community members can run the suite against their radio and submit the artifact directory. Curated captures get promoted into `fixtures/` to ground unit test data in reality.

## Included tests

- `recon.itest.ts`: handshake, identity, and safety assertions
- `tnf.itest.ts`: TNF lifecycle plus multi-client propagation verified through a second observer connection
- `scratch/` (gitignored): ephemeral experiments using the full harness

Verified against a FLEX-8600 on v4.2.20: 12/12 passing, radio left exactly as found.