### PR TITLE
Use router to manage modal visibility

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,14 +1,26 @@
 import { StatusBar } from "./components/statusbar";
 import { SidebarProvider, SidebarTrigger } from "./components/ui/sidebar";
 import { Toaster } from "./components/ui/toast";
-import useFlexRadio, { FlexRadioProvider } from "./context/flexradio";
+import useFlexRadio, {
+  ConnectionState,
+  FlexRadioProvider,
+} from "./context/flexradio";
 import "./app.css";
 import {
   ColorModeProvider,
   ColorModeScript,
   createLocalStorageManager,
 } from "@kobalte/core/color-mode";
-import { Show } from "solid-js";
+import {
+  HashRouter,
+  Navigate,
+  Route,
+  type RouteSectionProps,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "@solidjs/router";
+import { createEffect, Show } from "solid-js";
 import BaselineViewSidebar from "~icons/ic/baseline-view-sidebar";
 import MaterialSymbolsOpenInNew from "~icons/material-symbols/open-in-new";
 import { DebugBanner } from "./components/debug-mode/banner";
@@ -73,7 +85,46 @@ function AppInner() {
   );
 }
 
-function App() {
+/**
+ * Keeps the route in sync with connection state: losing the connection (or
+ * deep-linking while disconnected) redirects to /connect, stashing the
+ * intended destination in ?next= so a successful connect resumes it. Both
+ * redirects fire only on status transitions so the user can still dismiss
+ * the connect dialog while disconnected.
+ */
+function RouteGuard() {
+  const { state } = useFlexRadio();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  createEffect((prevStatus: ConnectionState | undefined) => {
+    const status = state.connectModal.status;
+    if (status === prevStatus) return status;
+    if (status === ConnectionState.disconnected) {
+      if (location.pathname !== "/connect") {
+        const next = location.pathname === "/" ? null : location.pathname;
+        navigate(
+          next ? `/connect?next=${encodeURIComponent(next)}` : "/connect",
+          { replace: true },
+        );
+      }
+    } else if (
+      status === ConnectionState.connected &&
+      location.pathname === "/connect"
+    ) {
+      const next = searchParams.next;
+      navigate(typeof next === "string" && next.startsWith("/") ? next : "/", {
+        replace: true,
+      });
+    }
+    return status;
+  }, undefined);
+
+  return null;
+}
+
+function AppRoot(props: RouteSectionProps) {
   const storageManager = createLocalStorageManager("vite-ui-theme");
 
   return (
@@ -114,6 +165,7 @@ function App() {
             <DebugModeProvider>
               <RtcProvider>
                 <FlexRadioProvider>
+                  <RouteGuard />
                   <RuntimeProvider>
                     <AudioProvider>
                       <ControlsProvider>
@@ -129,7 +181,19 @@ function App() {
         </PreferencesProvider>
         <Toaster />
       </ColorModeProvider>
+      {props.children}
     </>
+  );
+}
+
+function App() {
+  return (
+    <HashRouter root={AppRoot}>
+      <Route path="/" />
+      <Route path="/connect" />
+      <Route path="/settings/:tab" />
+      <Route path="*404" component={() => <Navigate href="/" />} />
+    </HashRouter>
   );
 }
 

--- a/apps/web/src/components/connect.tsx
+++ b/apps/web/src/components/connect.tsx
@@ -1,12 +1,7 @@
 import { getModelInfo } from "@repo/flexlib";
 import { Key } from "@solid-primitives/keyed";
-import {
-  type ComponentProps,
-  createEffect,
-  createSignal,
-  For,
-  Show,
-} from "solid-js";
+import { useMatch, useNavigate } from "@solidjs/router";
+import { type ComponentProps, createEffect, For, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import useFlexRadio, { ConnectionState } from "~/context/flexradio";
 import MdiCheckNetworkOutline from "~icons/mdi/check-network-outline";
@@ -46,31 +41,19 @@ const STATUS_MAP: Record<string, ComponentProps<typeof Badge>["variant"]> = {
 export default function Connect() {
   const { connect, disconnect, state, client } = useFlexRadio();
 
-  const [open, setOpen] = createSignal(
-    state.connectModal.status === ConnectionState.disconnected,
-  );
+  const navigate = useNavigate();
+  const match = useMatch(() => "/connect");
+  const open = () => Boolean(match());
 
+  // Opening the dialog acts as "disconnect" when a connection is live; the
+  // RouteGuard in app.tsx handles navigating here on connection loss and
+  // away again once connected.
   createEffect((lastOpen) => {
     if (open() && !lastOpen) {
       disconnect();
     }
     return open();
-  }, true);
-
-  createEffect((prevStatus) => {
-    const status = state.connectModal.status;
-    switch (status) {
-      case prevStatus:
-        break;
-      case ConnectionState.connected:
-        setOpen(false);
-        break;
-      case ConnectionState.disconnected:
-        setOpen(true);
-        break;
-    }
-    return status;
-  }, state.connectModal.status);
+  }, open());
 
   const label = () =>
     state.clientHandle ? "Disconnect from radio" : "Connect to radio";
@@ -80,7 +63,7 @@ export default function Connect() {
       open={open()}
       onOpenChange={(openState) => {
         (document.activeElement as HTMLElement)?.blur();
-        setOpen(openState);
+        navigate(openState ? "/connect" : "/");
       }}
     >
       <Tooltip>

--- a/apps/web/src/components/settings/index.tsx
+++ b/apps/web/src/components/settings/index.tsx
@@ -1,4 +1,5 @@
-import { createSignal, lazy } from "solid-js";
+import { useMatch, useNavigate } from "@solidjs/router";
+import { createEffect, lazy } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import useFlexRadio from "~/context/flexradio";
 import AreaChartIcon from "~icons/material-symbols/area-chart";
@@ -49,7 +50,7 @@ const tabs = {
   dax: lazy(() =>
     import("./dax-settings").then((m) => ({ default: m.DaxSettings })),
   ),
-  daxIq: lazy(() =>
+  "dax-iq": lazy(() =>
     import("./dax-iq-settings").then((m) => ({ default: m.DaxIqSettings })),
   ),
   audio: lazy(() =>
@@ -70,17 +71,24 @@ const tabs = {
   ),
   meters: lazy(() => import("./meters").then((m) => ({ default: m.Meters }))),
   profiles: ProfileSettings,
-  "import/export": lazy(() =>
+  "import-export": lazy(() =>
     import("./import-export").then((m) => ({ default: m.ImportExport })),
   ),
 };
 
 export function Settings() {
-  const [activeTab, setActiveTab] = createSignal<keyof typeof tabs | null>(
-    null,
-  );
+  const navigate = useNavigate();
+  const match = useMatch(() => "/settings/:tab");
   const { state } = useFlexRadio();
   const disconnected = () => !state.clientHandle;
+  const activeTab = () => {
+    const tab = match()?.params.tab;
+    return tab != null && tab in tabs ? (tab as keyof typeof tabs) : null;
+  };
+  const setActiveTab = (tab: keyof typeof tabs) => navigate(`/settings/${tab}`);
+  createEffect(() => {
+    if (match() && activeTab() === null) navigate("/", { replace: true });
+  });
   const activeTabComponent = () => {
     const tab = activeTab();
     return tab != null ? tabs[tab] : undefined;
@@ -89,7 +97,7 @@ export function Settings() {
     <>
       <Dialog
         open={activeTab() !== null}
-        onOpenChange={(open) => !open && setActiveTab(null)}
+        onOpenChange={(open) => !open && navigate("/")}
       >
         <Dynamic component={activeTabComponent()} />
       </Dialog>
@@ -155,7 +163,7 @@ export function Settings() {
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={disconnected()}
-            onSelect={() => setActiveTab("daxIq")}
+            onSelect={() => setActiveTab("dax-iq")}
           >
             <DropdownMenuIcon>
               <AreaChartIcon />
@@ -215,7 +223,7 @@ export function Settings() {
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={disconnected()}
-            onSelect={() => setActiveTab("import/export")}
+            onSelect={() => setActiveTab("import-export")}
           >
             <DropdownMenuIcon>
               <ApplicationExportIcon />


### PR DESCRIPTION
Set up solid-router to allow future features like deep linking. Currently, it's mainly used to manage modal visibility. 